### PR TITLE
Add a 'Developer Mode' to the RPC Server

### DIFF
--- a/rpcServer/rpcQWorker.js
+++ b/rpcServer/rpcQWorker.js
@@ -46,6 +46,25 @@ function connectVistaDatabase() {
     rpcFacade.setLocking(true); //default is to utilize mvdm locking
 
     rpcContexts = new RPCContexts(db);
+
+
+    // Add prototype RPC Locker model if we're in 'developer' mode, which would be set in the config
+    if (CONFIG.developerMode) {
+        LOGGER.info('***************** DEVELOPER MODE *****************');
+        LOGGER.debug('Loading Non-Clinical RPC Locker and VDM Models...');
+
+        try {
+            const devRPCModels = require('../../nonClinicalRPCs/prototypes'); // eslint-disable-line global-require
+
+            const rpcL = rpcFacade.getRPCLInstance();
+            rpcL.addLockerModel(devRPCModels.rpcLModel);
+            rpcL.addVDMModel(devRPCModels.vdmModel);
+
+            LOGGER.debug('Successfully loaded the Non-Clinical RPC Models!');
+        } catch (err) {
+            LOGGER.info(`ERROR loading the Non-Clinical RPC Models: ${err.message} [${err.code}]`);
+        }
+    }
 }
 
 function generateTransactionId() {


### PR DESCRIPTION
I'm opening a pull request because this change involves locked-down "production" products, and wanted your blessings.  This change is associated with an issue in the NonClinicalRPCs repo (https://github.com/vistadataproject/nonClinicalRPCs/issues/1)

In an attempt to promote 'eating our own dog food', this change would allow us to run the RPC Server - and in turn, CPRS - against (non-clinical) prototyped RPC Locker and VDM models while being as non-invasive as possible to the overall production demo functionality.

To activate "Developer Mode", a user would need to explicitly tweak the RPC Server configuration file by adding a 'developerMode' flag. This causes the queue worker to load the RPC locker and VDM models from the NonClinicalRPCs repo, assuming a VDP developer directory structure.

Without the explicitly-set 'developerMode' flag in the configuration, it will be as if the code block was never written.

For developers, running the RPC Server/CPRS with prototyped locker models would be as simple as:
1. Modify the `config.js` settings (change IP addresses and add `config.developerMode = true`)
2. Run the RPC Server (in 'Developer Mode')
3. Tweak CPRS shortcut to point to the updated RPC Broker IP address
4. Run CPRS
5. ...
6. **PROFIT** 💰 