### PR TITLE
Add Non-Clinical Emulators to the RPC Server Configuration

### DIFF
--- a/rpcServer/cfg/config.js
+++ b/rpcServer/cfg/config.js
@@ -36,6 +36,18 @@ config.lockers = [{
     name: 'Clinical Emulator',
     path: 'mvdm/cRPCL',
     models: ['./modelsClinical'],
+}, {
+    name: 'Non-Clinical Emulator',
+    path: 'mvdm/ncRPCL',
+    models: ['mvdm/nonClinicalRPCs'],
+}, {
+    name: 'JS Utility Emulator',
+    path: 'mvdm/ncRPCL',
+    models: ['mvdm/nonClinicalRPCs/utility'],
+}, {
+    name: 'Out-Of-Scope Emulator',
+    path: 'mvdm/ncRPCL',
+    models: ['mvdm/nonClinicalRPCs/outofscope'],
 }];
 
 try {

--- a/rpcServer/modelsClinical.js
+++ b/rpcServer/modelsClinical.js
@@ -43,8 +43,7 @@ const rpcLModel = [].concat(
     require('mvdm/allergies/rpcLAllergiesModel').rpcLModel,
     require('mvdm/problems/rpcLProblemModel').rpcLModel,
     require('mvdm/vitals/rpcLVitalsModel').rpcLModel,
-    require('mvdm/patient/rpcLPatientModel').rpcLModel,
-    require('mvdm/utilityRPCs/rpcLRemoteUtilitiesModel').rpcLModel);
+    require('mvdm/patient/rpcLPatientModel').rpcLModel);
 
 module.exports = {
     vdmModel,


### PR DESCRIPTION
This minor change adds the Non-Clinical emulators to the RPC server default configuration.  These changes assume that the NC models have been moved into the MVDM, and shouldn't be merged (read: will throw errors the RPC server setup) until the NC emulators are moved.  However, the changes do the following:
* Create 3 new emulators:
    - Non-Clinical Emulator (parameter/file RPCs)
    - JS Utility Emulator (JS only utility RPCs)
    - Out-Of-Scope Emulator (runs the [out-of-scope](http://vistadataproject.info/artifacts/cprsRPCBreakdown/bdOut_of_Scope) RPCs through the RPC Runner, but gives us emulation credit.
* Removes the JS utility reference from the clinical model list

I've tested it against my [forked MVDM repo updated with non-clinicals](https://github.com/mfuroyama/MVDM) and it seems to work.   