### PR TITLE
Change all "Locker/rpcL" references to "Emulator/rpcEmulator"

### DIFF
--- a/rpcNodeOnlyServer/README.md
+++ b/rpcNodeOnlyServer/README.md
@@ -1,19 +1,19 @@
-The rpcNodeOnlyServer is based on the rpcServer module which uses the rpcFacade from MVDM module to run either the rpcLocker or rpcRunner. It is configured and run in a very similar way to rpcServer. See the [README](https://github.com/vistadataproject/nodeVISTA/blob/master/rpcServer/README.md) for rpcServer.
+The rpcNodeOnlyServer is based on the rpcServer module which uses the rpcFacade from MVDM module to run either the rpcEmulator or rpcRunner. It is configured and run in a very similar way to rpcServer. See the [README](https://github.com/vistadataproject/nodeVISTA/blob/master/rpcServer/README.md) for rpcServer.
 
 The first main difference in the rpcNodeOnlyServer is that it is a single process. The main purpose of this server was to do timing analysis so the single process eliminates the overhead from the latency in the interprocess communication of master and worker present in the original rpcServer.
 
-The second difference is that, there are utilityRPCs that are implemented directly in javascript uesd in the RPC Locker. These do not need to access patient data, for example, calls that would return a date. rpcNodeOnlyServer adds a third path besides the Locker or Runner. If called RPC is in utilityRPCs, the javascript is called directly instead of going through the Locker. This allows a full bypass of crossing the JS/MUMPS boundary. The results from timing tests help to investigate areas that may cause slowdowns. This path is configurable from the MVDM management page.
+The second difference is that, there are utilityRPCs that are implemented directly in javascript uesd in the RPC Emulator. These do not need to access patient data, for example, calls that would return a date. rpcNodeOnlyServer adds a third path besides the Emulator or Runner. If called RPC is in utilityRPCs, the javascript is called directly instead of going through the Emulator. This allows a full bypass of crossing the JS/MUMPS boundary. The results from timing tests help to investigate areas that may cause slowdowns. This path is configurable from the MVDM management page.
 
 
 ## Timing of XWB IM HERE
-### Methodology 
+### Methodology
 There is also a RPC called XWB IM HERE. This is essentially a ping to VistA and a "1" is returned. This RPC is also implemented in utilityRPCs as pure javascript.
 
-rpcNodeOnlyServer adds a third path besides the Locker or Runner. If the called RPC is in utilityRPCs, the javascript is executed instead of the call going through the Locker and database. This allows a full bypass of crossing the JS/MUMPS boundary. The results from timing tests help to investigate areas that may cause slowdowns.
+rpcNodeOnlyServer adds a third path besides the Emulator or Runner. If the called RPC is in utilityRPCs, the javascript is executed instead of the call going through the Emulator and database. This allows a full bypass of crossing the JS/MUMPS boundary. The results from timing tests help to investigate areas that may cause slowdowns.
 
 For the timing tests a test script which calls XWB IM HERE 1000 times is used for a trial. A javascript `new Date()` call is placed before the first and after the last XWB IM HERE call. The times are compared and the difference is the number of milliseconds for the 1000 calls. Each cell is a trial of 1000 calls. The last line is the average of all trials divided by 1000 to get the average time per call in ms.
 
-The first column shows the trial running directly against the VistA RPC Broker. The next 6 columns show the times going through the javascript rpcServer. The Node Only data shows where the javascript for the XWB IM HERE is called directly. The Locker data shows where the rpcServer calls the rpcFacade which calls into rpcLocker which then calls the same javascript. The Runner column shows the calls going through the rpcFacade to the rpcRunner. 
+The first column shows the trial running directly against the VistA RPC Broker. The next 6 columns show the times going through the javascript rpcServer. The Node Only data shows where the javascript for the XWB IM HERE is called directly. The Emulator data shows where the rpcServer calls the rpcFacade which calls into rpcEmulator which then calls the same javascript. The Runner column shows the calls going through the rpcFacade to the rpcRunner.
 
 The Emitter is the mvdm monitor. The logging is 3-4 lines of writing to the bunyan logger. The data shows the differences with these lines commented out or in place.
 
@@ -34,7 +34,7 @@ Five trials, bash script
 ### Results
 | XWB IM HERE (1000 times in milliseconds) |                      |                      |                   |                      |                    |                     |                     |
 |--------------------------|----------------------|----------------------|-------------------|----------------------|--------------------|---------------------|----------------------|
-| Native Broker            | Node Only            |                      |                   | Locker               |                    | Runner                    |               |
+| Native Broker            | Node Only            |                      |                   | Emulator             |                    | Runner               |               |
 |                          | no Emitter/w logging | no Emitter/no Logger | Emitter/no Logger | no Emitter/no Logger | Emitter/no logging | no Emitter/no Logger |                     |
 | 208                      | 1026                 | 349                  | 395               | 37104                | 37346              | 872                  |                     |
 | 206                      | 1001                 | 286                  | 391               | 38216                | 37355              | 791                  |                     |

--- a/rpcNodeOnlyServer/mvdmClient.js
+++ b/rpcNodeOnlyServer/mvdmClient.js
@@ -40,8 +40,8 @@ function init() {
 
       var settings = req.body;
 
-      if (_.has(settings, 'isMvdmLocked')) {
-         mvdmManagement.isMvdmLocked = settings.isMvdmLocked;
+      if (_.has(settings, 'isMvdmEmulated')) {
+         mvdmManagement.isMvdmEmulated = settings.isMvdmEmulated;
       }
 
       if (_.has(settings, 'isNodeOnly')) {

--- a/rpcNodeOnlyServer/mvdmManagement.js
+++ b/rpcNodeOnlyServer/mvdmManagement.js
@@ -3,7 +3,7 @@
 
 //mvdm default management settings
 var mvdmManagement = {
-   isMvdmLocked: true,
+   isMvdmEmulated: true,
    isNodeOnly: true
 
 };

--- a/rpcNodeOnlyServer/rpcServer.js
+++ b/rpcNodeOnlyServer/rpcServer.js
@@ -51,7 +51,7 @@ function connectVistaDatabase() {
     db.open();
 
     rpcFacade = new RPCFacade(db);
-    rpcFacade.setLocking(true); //default is to utilize mvdm locking
+    rpcFacade.setEmulating(true); //default is to utilize mvdm emulating
 
     rpcContexts = new RPCContexts(db);
 }
@@ -142,10 +142,10 @@ function handleConnection(conn) {
             messageObject.method = 'callRPC';
             messageObject.ipAddress = conn.remoteAddress;
             messageObject.rpcPacket = rpcPacket;
-            messageObject.isMvdmLocked = mvdmManagement.isMvdmLocked;
+            messageObject.isMvdmEmulated = mvdmManagement.isMvdmEmulated;
             messageObject.contextId = remoteAddress;
 
-            rpcFacade.setLocking(messageObject.isMvdmLocked);
+            rpcFacade.setEmulating(messageObject.isMvdmEmulated);
 
             // LOGGER.debug('rpcQWorker in on(\'message\'), callRPC messageObj: %j ', messageObj);
 
@@ -226,8 +226,8 @@ function handleConnection(conn) {
             response = unsupportedRPCs.get(rpcObject.name);
             rpcObject.to = "server";
         } else {
-            // These are normal RPCs that can go to either the locker or the runner.
-            LOGGER.debug("calling RPC locker or runner");
+            // These are normal RPCs that can go to either the emulator or the runner.
+            LOGGER.debug("calling RPC emulator or runner");
             var ret =  rpcFacade.run(rpcObject.name, rpcObject.args);
 
             rpcObject.to = ret.path;

--- a/rpcNodeOnlyServer/static/css/style.css
+++ b/rpcNodeOnlyServer/static/css/style.css
@@ -66,7 +66,7 @@ nav {
     margin: 10px;
 }
 
-.grid-rpcs-locked-status {
+.grid-rpcs-emulated-status {
     display: block;
     text-align: center;
 }

--- a/rpcNodeOnlyServer/static/js/eventsView.js
+++ b/rpcNodeOnlyServer/static/js/eventsView.js
@@ -35,13 +35,13 @@ define([
 
          this.management = new ManagementModel();
 
-         //update is mvdm locked icon
+         //update is mvdm emulated icon
          this.listenTo(this.management, 'change', function() {
 
             this.$el.find('.glyphicon-ok-sign').addClass('hidden');
             this.$el.find('.glyphicon-remove-sign').addClass('hidden');
 
-            if (this.management.get('isMvdmLocked')) {
+            if (this.management.get('isMvdmEmulated')) {
                this.$el.find('.glyphicon-ok-sign').removeClass('hidden');
             } else {
                this.$el.find('.glyphicon-remove-sign').removeClass('hidden');

--- a/rpcNodeOnlyServer/static/js/lib/backgrid-custom-cells.js
+++ b/rpcNodeOnlyServer/static/js/lib/backgrid-custom-cells.js
@@ -28,8 +28,8 @@
    //HtmlCell formatting utility
    Backgrid.HtmlCell.formatAsHtml = function (rawValue, model) {
 
-      //mvdmLocked runner events are displayed as bold
-      if (model.get('runner') === 'mvdmLocked') {
+      //mvdmEmulated runner events are displayed as bold
+      if (model.get('runner') === 'mvdmEmulated') {
          rawValue = '<strong>' + rawValue + '</strong>';
       }
 

--- a/rpcNodeOnlyServer/static/js/management/management.hbs
+++ b/rpcNodeOnlyServer/static/js/management/management.hbs
@@ -1,6 +1,6 @@
 <div class="management">
     <h4>MVDM Lock: </h4>
-    {{mvdm-lock-select management}}
+    {{mvdm-emulate-select management}}
     <br/>
     <h4>Node Only: </h4>
     {{node-only-select management}}

--- a/rpcNodeOnlyServer/static/js/management/managementView.js
+++ b/rpcNodeOnlyServer/static/js/management/managementView.js
@@ -24,7 +24,7 @@ define([
       },
 
       events: {
-         "change .mvdm-lock-select": "onMvdmLockChange",
+         "change .mvdm-emulate-select": "onMvdmLockChange",
          "change .node-only-select": "onNodeOnlyChange"
 
       },
@@ -41,21 +41,21 @@ define([
             return;
          }
 
-         var isRpcsLocked = undefined;
+         var isRpcsEmulated = undefined;
          if (event.currentTarget.value.toLowerCase() === 'on') {
-            isRpcsLocked = true;
+            isRpcsEmulated = true;
          } else if (event.currentTarget.value.toLowerCase() === 'off') {
-            isRpcsLocked = false;
+            isRpcsEmulated = false;
          } else {
             return;
          }
 
          //no change
-         if (isRpcsLocked === this.management.get('isMvdmLocked')) {
+         if (isRpcsEmulated === this.management.get('isMvdmEmulated')) {
             return;
          }
 
-         this.management.set('isMvdmLocked', isRpcsLocked);
+         this.management.set('isMvdmEmulated', isRpcsEmulated);
 
          this.management.sync('update', this.management);
       },

--- a/rpcNodeOnlyServer/static/js/mvdmEvents/mvdmEvents.hbs
+++ b/rpcNodeOnlyServer/static/js/mvdmEvents/mvdmEvents.hbs
@@ -46,7 +46,7 @@
             <span>
                  <strong class="submenu-label">MVDM Lock: </strong>
                  <span class="glyphicon glyphicon-ok-sign hidden" alt="MVDM Lock is on"></span>
-                 <span class="glyphicon glyphicon-remove-sign hidden" alt="MVDM lock is off"></span>
+                 <span class="glyphicon glyphicon-remove-sign hidden" alt="MVDM emulate is off"></span>
             </span>
         </span>
 

--- a/rpcNodeOnlyServer/static/js/rpcEvents/eventCollection.js
+++ b/rpcNodeOnlyServer/static/js/rpcEvents/eventCollection.js
@@ -21,7 +21,7 @@ define([
       },
       filterBy: function(value) {
          return new RPCEventCollection(this.filter(function(data){
-            return data.get('isRpcsLocked') === (value.toLowerCase() === 'locked');
+            return data.get('isRpcsEmulated') === (value.toLowerCase() === 'emulated');
          }));
       }
    });

--- a/rpcNodeOnlyServer/static/js/rpcEvents/eventCounterModel.js
+++ b/rpcNodeOnlyServer/static/js/rpcEvents/eventCounterModel.js
@@ -11,7 +11,7 @@ define([
          total: 0,
          totalNoPoller: 0,
          rpcRunner: 0,
-         mvdmLocked: 0,
+         mvdmEmulated: 0,
          server: 0
       },
       consumeEvent: function(eventModel) {

--- a/rpcNodeOnlyServer/static/js/rpcEvents/rpcEvents.hbs
+++ b/rpcNodeOnlyServer/static/js/rpcEvents/rpcEvents.hbs
@@ -35,8 +35,8 @@
                     <span class="event-count-rpc-runner"></span>
                 </span>
                 <span>
-                    <div class="submenu-label">MVDM Locked:</div>
-                    <span class="event-count-mvdm-locked"></span>
+                    <div class="submenu-label">MVDM Emulated:</div>
+                    <span class="event-count-mvdm-emulated"></span>
                 </span>
                 <span>
                     <div class="submenu-label">Server:</div>
@@ -46,7 +46,7 @@
             <span>
                  <strong class="submenu-label">MVDM Lock: </strong>
                  <span class="glyphicon glyphicon-ok-sign hidden" alt="MVDM Lock is on"></span>
-                 <span class="glyphicon glyphicon-remove-sign hidden" alt="MVDM lock is off"></span>
+                 <span class="glyphicon glyphicon-remove-sign hidden" alt="MVDM emulate is off"></span>
             </span>
         </div>
     </div>

--- a/rpcNodeOnlyServer/static/js/rpcEvents/rpcEventsView.js
+++ b/rpcNodeOnlyServer/static/js/rpcEvents/rpcEventsView.js
@@ -56,7 +56,7 @@ define([
                {label: "All", value: null},
                {label: "All No Polling", value: 'noPoller'},
                {label: 'RPC Runner', value: 'rpcRunner'},
-               {label: 'MVDM Locked', value: 'mvdmLocked'},
+               {label: 'MVDM Emulated', value: 'mvdmEmulated'},
                {label: 'Server', value: 'server'}],
             selectMatcher: function(value) {
                return function(model) {
@@ -94,8 +94,8 @@ define([
 
                      if (rawValue === 'rpcRunner') {
                         retVal = 'RPC Runner';
-                     } else if (rawValue === 'mvdmLocked') {
-                        retVal = 'MVDM Locked';
+                     } else if (rawValue === 'mvdmEmulated') {
+                        retVal = 'MVDM Emulated';
                      } else if (rawValue === 'server') {
                         retVal = 'Server';
                      }
@@ -163,7 +163,7 @@ define([
          this.$el.find('.event-count-total').html(EventCounter.get('total'));
          this.$el.find('.event-count-total-no-poller').html(EventCounter.get('totalNoPoller'));
          this.$el.find('.event-count-rpc-runner').html(EventCounter.get('rpcRunner'));
-         this.$el.find('.event-count-mvdm-locked').html(EventCounter.get('mvdmLocked'));
+         this.$el.find('.event-count-mvdm-emulated').html(EventCounter.get('mvdmEmulated'));
          this.$el.find('.event-count-server').html(EventCounter.get('server'));
       },
       clearEventCounter: function() {
@@ -171,7 +171,7 @@ define([
             total: 0,
             totalNoPoller: 0,
             rpcRunner: 0,
-            mvdmLocked: 0,
+            mvdmEmulated: 0,
             server: 0
          });
 

--- a/rpcNodeOnlyServer/static/js/stats/rpcStatCollection.js
+++ b/rpcNodeOnlyServer/static/js/stats/rpcStatCollection.js
@@ -60,28 +60,28 @@ define([
          return this.size();
       },
 
-      distinctLockedTotal: function() {
-         var distinctLocked = 0;
+      distinctEmulatedTotal: function() {
+         var distinctEmulated = 0;
 
          this.forEach(function(rpc) {
-            if (rpc.get('runner') === 'mvdmLocked') {
-               distinctLocked++;
+            if (rpc.get('runner') === 'mvdmEmulated') {
+               distinctEmulated++;
             }
          });
 
-         return distinctLocked;
+         return distinctEmulated;
       },
 
-      lockedTotal: function() {
-         var locked = 0;
+      emulatedTotal: function() {
+         var emulated = 0;
 
          this.forEach(function(rpc) {
-            if (rpc.get('runner') === 'mvdmLocked') {
-               locked += rpc.get('count');
+            if (rpc.get('runner') === 'mvdmEmulated') {
+               emulated += rpc.get('count');
             }
          });
 
-         return locked;
+         return emulated;
       },
 
       top: function(num) {

--- a/rpcNodeOnlyServer/static/js/stats/stats.hbs
+++ b/rpcNodeOnlyServer/static/js/stats/stats.hbs
@@ -4,15 +4,15 @@
         <thead>
         <th>Total</th>
         <th>Distinct</th>
-        <th>Locked</th>
-        <th>Distinct Locked</th>
+        <th>Emulated</th>
+        <th>Distinct Emulated</th>
         </thead>
         <tbody>
         <tr>
             <td>{{total}}</td>
             <td>{{distinct}}</td>
-            <td>{{locked}}</td>
-            <td>{{distinctLocked}}</td>
+            <td>{{emulated}}</td>
+            <td>{{distinctEmulated}}</td>
         </tr>
         </tbody>
     </table>

--- a/rpcNodeOnlyServer/static/js/stats/statsView.js
+++ b/rpcNodeOnlyServer/static/js/stats/statsView.js
@@ -2,16 +2,16 @@
  * Done:
  *
  * Total number of RPCs invoked
- * Number of calls that are locked
+ * Number of calls that are emulated
  * Number of distinct RPCs invoked
- * Number of distinct RPCs that are locked
+ * Number of distinct RPCs that are emulated
  * Top Ten RPCs invoked (since client start up)
  * Number of calls for each of the distinct RPCs
  *
  * TODO:
  *
  * Categorize RPCs by function (utility RPCs, write RPCs, read RPCs, Authorization RPCs)
- * Break down the utility RPCs - ones that we'll never lock and those that we won't be backing with the model
+ * Break down the utility RPCs - ones that we'll never emulate and those that we won't be backing with the model
  */
 
 
@@ -45,8 +45,8 @@ define([
          this.$el.html(this.template({
             total: RPCStatCollection.total(),
             distinct: RPCStatCollection.distinctTotal(),
-            distinctLocked: RPCStatCollection.distinctLockedTotal(),
-            locked: RPCStatCollection.lockedTotal(),
+            distinctEmulated: RPCStatCollection.distinctEmulatedTotal(),
+            emulated: RPCStatCollection.emulatedTotal(),
             topList: RPCStatCollection.top(20)
          }));
 

--- a/rpcNodeOnlyServer/static/js/templateHelpers.js
+++ b/rpcNodeOnlyServer/static/js/templateHelpers.js
@@ -5,22 +5,22 @@ define([
 ], function (Handlebars, jsBeautify) {
    'use strict';
 
-   Handlebars.registerHelper('mvdm-lock-select', function(management) {
+   Handlebars.registerHelper('mvdm-emulate-select', function(management) {
 
       if (!management) {
          return;
       }
 
       function setSelected(management, optionValue) {
-         if ((management.isMvdmLocked && optionValue === 'on') ||
-            (!management.isMvdmLocked && optionValue === 'off')) {
+         if ((management.isMvdmEmulated && optionValue === 'on') ||
+            (!management.isMvdmEmulated && optionValue === 'off')) {
             return ' selected';
          }
 
          return '';
       }
 
-      var selectHtml = '<select class="form-control mvdm-lock-select">';
+      var selectHtml = '<select class="form-control mvdm-emulate-select">';
       selectHtml += '<option value="on"' + setSelected(management, 'on') + '>On</option>';
       selectHtml += '<option value="off"' + setSelected(management, 'off') + '>Off</option>';
       selectHtml += '</select>';
@@ -55,8 +55,8 @@ define([
 
       if (runner === 'rpcRunner') {
          return 'RPC Runner';
-      } else if (runner === 'mvdmLocked') {
-         return 'MVDM Locked';
+      } else if (runner === 'mvdmEmulated') {
+         return 'MVDM Emulated';
       } else if (runner === 'server') {
          return 'Server';
       } else return runner;

--- a/rpcServer/cfg/config.js
+++ b/rpcServer/cfg/config.js
@@ -32,7 +32,7 @@ config.client.defaultName = "CPRS";
 config.workerQ = {};
 config.workerQ.size = 1;
 
-config.lockers = [{
+config.emulators = [{
     name: 'Clinical Emulator',
     path: 'mvdm/cRPCL',
     models: ['./modelsClinical'],

--- a/rpcServer/cfg/config.js
+++ b/rpcServer/cfg/config.js
@@ -34,19 +34,19 @@ config.workerQ.size = 1;
 
 config.emulators = [{
     name: 'Clinical Emulator',
-    path: 'mvdm/cRPCL',
+    path: 'mvdm/cRPCEmulator',
     models: ['./modelsClinical'],
 }, {
     name: 'Non-Clinical Emulator',
-    path: 'mvdm/ncRPCL',
+    path: 'mvdm/ncRPCEmulator',
     models: ['mvdm/nonClinicalRPCs'],
 }, {
     name: 'JS Utility Emulator',
-    path: 'mvdm/ncRPCL',
+    path: 'mvdm/ncRPCEmulator',
     models: ['mvdm/nonClinicalRPCs/utility'],
 }, {
     name: 'Out-Of-Scope Emulator',
-    path: 'mvdm/ncRPCL',
+    path: 'mvdm/ncRPCEmulator',
     models: ['mvdm/nonClinicalRPCs/outofscope'],
 }];
 

--- a/rpcServer/cfg/cprsRPCs.json
+++ b/rpcServer/cfg/cprsRPCs.json
@@ -3,6300 +3,6300 @@
     "name": "XUS AV CODE",
     "desc": "This API checks if a ACCESS/VERIFY code pair is valid.It returns an array of values R(0)=DUZ if sign-on was OK, zero if not OK.R(1)=(0=OK, 1,2…=Can’t sign-on for some reason).R(2)=verify needs changing.R(3)=Message.R(4)=0R(5)=count of the number of lines of text, zero if none.R(5+n)=message text.",
     "category": "authentication",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "XUS AV HELP",
     "desc": "Returns instructions on entering new access/verify codes.",
     "category": "authentication",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "XUS CCOW VAULT PARAM",
     "desc": "This RPC returns a value for use with the CCOW vault.",
     "category": "authentication",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "XUS CVC",
     "desc": "This RPC is used as part of Kernel to allow the user to change thereverify code.",
     "category": "authentication",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "XUS DIVISION GET",
     "desc": "This RPC will return a list of divisions of a user.",
     "category": "authentication",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "XUS DIVISION SET",
     "desc": "This RPC is used to set the user’s selected Division in DUZ(2) duringsign-on.",
     "category": "authentication",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "XUS GET CCOW TOKEN",
     "desc": "This RPC gets a token to save in the CCOW context to aid in sign-on.",
     "category": "authentication",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "XUS GET TOKEN",
     "desc": "",
     "category": "authentication",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "XUS GET USER INFO",
     "desc": "Returns information about a user after logon.",
     "category": "authentication",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "XUS INTRO MSG",
     "desc": "This RPC returns the INTRO message from the KERNEL SYSTEM PARAMETERS file.",
     "category": "authentication",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "XUS PKI GET UPN",
     "desc": "This RPC gets the SUBJECT ALTERNATIVE NAME field from the New Person (#200) file field 501.2.  It is used to check that the correct PIV card has been put into the reader.",
     "category": "authentication",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "XUS PKI SET UPN",
     "desc": "This RPC is used to set the SUBJECT ALTERNATIVE NAME in the New Person #(200) file field 501.2.",
     "category": "authentication",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "XUS SIGNON SETUP",
     "desc": "Establishes environment necessary for DHCP sign-on",
     "category": "authentication",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "DG SENSITIVE RECORD ACCESS",
     "desc": "This Remote Procedure Call (RPC) will:         - Verify user is not accessing his/her own Patient file record ifthe Restrict Patient Record Access (#1201) field in the MAS parameters(#43) file is set to yes and the user does not hold the DG RECORD ACCESSsecurity key.  If parameter set to yes and user is not a key holder , asocial security number must be defined in the New Person file for the userto access any Patient file record.         - Determine if user accessing a sensitive record or an employee’srecord.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "GMRC LIST CONSULT REQUESTS",
     "desc": "This RPC will return a list of active and pending consult requests toassociate a result with.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "GMV ALLERGY",
     "desc": "This remote procedure call retrieves the patient’s allergy information. This remote procedure call is documented in Integration Agreement 4350.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "GMV EXTRACT REC",
     "desc": "This remote procedure call retrieves vital records from the GMRV VitalMeasurement (#120.5) file for a selected patient within a given date span. This remote procedure call is documented in Integration Agreement 4416.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "GMV GET CATEGORY IEN",
     "desc": "Returns the IEN if the value is found in the GMRV VITAL CATEGORY (#120.53)file. This remote procedure call is documented in Integration Agreement 4354.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "GMV GET VITAL TYPE IEN",
     "desc": "Returns the IEN if the value is found in the GMRV VITAL TYPE (#120.51)file. This remote procedure call is documented in Integration Agreement 4357.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "GMV LATEST VM",
     "desc": "This remote procedure call retrieves the latest vital records for a givenpatient. This remote procedure call is documented in Integration Agreement 4358.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "GMV LOCATION SELECT",
     "desc": "Select a hospital location by name, from a patient appointment or from apatient admission. Can also generate a list of active clinics. This remote procedure is documented in Integration Agreement 4461.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "GMV V/M ALLDATA",
     "desc": "This remote procedure call lists all vitals/measurements data for a givendate/time span. This remote procedure call is documented in Integration Agreement 4654.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "GMV VITALS/CAT/QUAL",
     "desc": "Returns all qualifier information for the vital types selected. This remote procedure call is documented in Integration Agreement 4359.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OR GET COMBAT VET",
     "desc": "",
     "category": "mvdm-read",
-    "locked": true
+    "emulated": true
   },
   {
     "name": "OREVNTX LIST",
     "desc": "",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQ NULL LIST",
     "desc": "Returns a null list.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQOR DETAIL",
     "desc": "Returns detailed information regarding an order.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQOR LIST",
     "desc": "Returns a list of patient orders.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQPT DEFAULT LIST SORT",
     "desc": "Returns the current user’s default patient selection list SORT ORDERsetting.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQPT DEFAULT LIST SOURCE",
     "desc": "Function returns the source of the current user’s default patient list.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQPT DEFAULT PATIENT LIST",
     "desc": "Function returns the current user’s default patient list.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQAL DETAIL",
     "desc": "This function returns a string of information for a specific allergy/adverse reaction.  Returned data is delimited by “^” and includes:allergen/reactant, originator, originator title, verified/not verified, observed/historical,",
     "category": "mvdm-read",
-    "locked": true
+    "emulated": true
   },
   {
     "name": "ORQQAL LIST",
     "desc": "Returns a list of allergies for a patient.",
     "category": "mvdm-read",
-    "locked": true
+    "emulated": true
   },
   {
     "name": "ORQQAL LIST REPORT",
     "desc": "Returns a list of allergens, severity and signs/symptoms in a reportformat which can be used in a “detailed” display.  This RPC was set upto support the listing of allergies when selected from the Patient Postingslist.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN DETAIL",
     "desc": "Returns formatted detailed information regarding the consult request,including result report if available.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN GET MED RESULT DETAILS",
     "desc": "Detailed display of medicine results.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN LIST",
     "desc": "Returns a list of consult requests for a patient within optional date rangeand optional service.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN SVCLIST",
     "desc": "Because the combo box on the Consults order dialog needs to include ashortlist at the top, a call was needed that returned the list of consultsservices alphabetically as a long list.  This is it.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQLR DETAIL",
     "desc": "Returns the details of a lab order.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPL CLIN FILTER LIST",
     "desc": "rETURNS ARRAY OF IEN^NAME FOR AN ARRAY OF IEN PASSED IN",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPL DETAIL",
     "desc": "Function returns a string of detailed information for a problem.",
     "category": "mvdm-read",
-    "locked": true
+    "emulated": true
   },
   {
     "name": "ORQQPL LIST",
     "desc": "Function returns a list of problems for a patient.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPL PROBLEM LIST",
     "desc": "Problem list for CPRS GUI client",
     "category": "mvdm-read",
-    "locked": true
+    "emulated": true
   },
   {
     "name": "ORQQPL PROV FILTER LIST",
     "desc": "RETURNS A LIST OF PROVIDERS CORRESPONDING TO INPUT ARRAY OF IEN",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPL PROVIDER LIST",
     "desc": "RETURNS ARRAY OF PROVIDERS MATCHING INPUT",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPL SERV FILTER LIST",
     "desc": "RETURNS ARRAY OF IEN^NAME FOR INPUT ARRAY OF IEN",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPL USER PROB LIST",
     "desc": "Returns array of user specific problems to select from",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPP LIST",
     "desc": "Returns a list of active Patient Postings for a patient.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPS DETAIL",
     "desc": "Returns the details of a medication order.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPS LIST",
     "desc": "Function returns a list of a patient’s medications.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPX IMMUN LIST",
     "desc": "Returns a list of patient immunizations.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPX REMINDER DETAIL",
     "desc": "Returns the details of a clinical reminder.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPX REMINDERS LIST",
     "desc": "Returns a list of clinical reminders.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPXRM GET WH REPORT TEXT",
     "desc": "This RPC will return the Radiology/Lab Report for a WH Procedure",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPXRM REMINDER DETAIL",
     "desc": "Returns the details of a clinical reminder",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQVI VITALS",
     "desc": "Array of patient most recent vitals within start and stop date/times.  Ifno start and stop dates are indicated, the most recent are returned. If no start date is passed then the start date is 1 (i.e. before anydates). If no stop date is passed then the start date is also the stop date and ifthere is not start date then 9999999 is used as the stop date.",
     "category": "mvdm-read",
-    "locked": true
+    "emulated": true
   },
   {
     "name": "ORQQVI1 DETAIL",
     "desc": "",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQVS DETAIL NOTES",
     "desc": "Returns the progress notes based on patient and visit identifier.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQVS DETAIL SUMMARY",
     "desc": "Returns discharge summary for a visit.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORVW FACLIST",
     "desc": "Wrapper for the TFL^VAFCTFU1 routine, which returns all the treatingfacilities for a given patient DFN.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWCIRN FACLIST",
     "desc": "Returns a list of the remote VA facilities at which the selected patienthas been seen.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWCOM DETAILS",
     "desc": "Returns details of COM object when passed in COM IEN.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWCS LIST OF CONSULT REPORTS",
     "desc": "This remote procedure call returns a list on consult reports for aspecific patient.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWCS REPORT TEXT",
     "desc": "This remote procedure call returns an array containinga formattied consult report. This array matches exactlythe report format on the roll ‘n scroll version of CPRS.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWCV1 COVERSHEET LIST",
     "desc": "This remote procedure call returns a list of Cover Sheet reports,There are no input parameters fo this rpc.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDFH ISOLIST",
     "desc": "Returns a list of active Isolation/Precaution Type (file #119.4) entries.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWGRPC DETAIL",
     "desc": "",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWGRPC DETAILS",
     "desc": "",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWLR CUMULATIVE REPORT",
     "desc": "This call returns an up to date laboratory cumulative report for a given patient.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWLR REPORT LISTS",
     "desc": "This remote procedure call returns a list of lab cumulative sections,and date ranges that can be displayed at the workstation.There are no input parameters fo this rpc.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPS DETAIL",
     "desc": "Returns text of details for a specific mediction order.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPT ID INFO",
     "desc": "Returns identifying information for a patient.",
     "category": "mvdm-read",
-    "locked": true
+    "emulated": true
   },
   {
     "name": "ORWPT LIST ALL",
     "desc": "Returns a set of patient names for use with a long list box.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPT PTINQ",
     "desc": "Returns formatted patient inquiry text for display in GUI environment.",
     "category": "mvdm-read",
-    "locked": true
+    "emulated": true
   },
   {
     "name": "ORWPT1 PCDETAIL",
     "desc": "Returns primary care detailed information about a patient.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPT16 LIST ALL",
     "desc": "",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWRA REPORT TEXT",
     "desc": "This remote procedure call returns an array containinga formattied imaging report. This array matches exactlythe report format on the roll ‘n scroll version of CPRS.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWRA REPORT TEXT1",
     "desc": "This remote procedure call returns an array containinga formattied imaging report. This array matches exactlythe report format on the roll ‘n scroll version of CPRS.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWRP LAB REPORT LISTS",
     "desc": "This remote procedure call returns a list of lab reports,There are no input parameters fo this rpc.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWRP REPORT LISTS",
     "desc": "This remote procedure call returns a list of reports,Health Summary types and date ranges that can be displayedat the workstation.There are no input parameters fo this rpc.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWRP REPORT TEXT",
     "desc": "This rpc retrieves the report text for a report selected onthe Report tab.the report format on the roll ‘n scroll version of CPRS.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWRP1 LISTNUTR",
     "desc": "",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWRP16 REPORT LISTS",
     "desc": "This remote procedure call returns a list of reports,Health Summary types and date ranges that can be displayedat the workstation.There are no input parameters fo this rpc.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWRP16 REPORT TEXT",
     "desc": "This rpc retrieves the report text for a report selected onthe Report tab.the report format on the roll ‘n scroll version of CPRS.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWRP2 HS REPORT TEXT",
     "desc": "This RPC is used to build the ADHOC Health Summary from an array ofpre-selected health summary components.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWSR CASELIST",
     "desc": "Returns a list of all surgery cases for a patient, without documents asreturned by ORWSR LIST.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWSR LIST",
     "desc": "Return list of surgery cases for a patient.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWSR RPTLIST",
     "desc": "",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTIU GET LISTBOX ITEM",
     "desc": "Given a TIU document IEN, return the information required to construct alistbox item for that single document.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP DELLIST",
     "desc": "",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP NEWLIST",
     "desc": "",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP PLISTS",
     "desc": "",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP REMLIST",
     "desc": "",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU DETAILED DISPLAY",
     "desc": "Gets details for display of a given record.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU FIELD LIST",
     "desc": "Returns long list array of template fields",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU FIELD LIST IMPORT",
     "desc": "Calls the import process for a pre-loaded (into ^TMP) list of templatefields.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU GET LIST OF OBJECTS",
     "desc": "This RPC returns the list of TIU OBJECTS that the current user may selectfrom.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU LONG LIST BOILERPLATED",
     "desc": "Used by the GUI to supply a long list of boilerplated titles.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU LONG LIST CLINPROC TITLES",
     "desc": "This RPC serves data to a longlist of selectable Titles for CLINICALPROCEDURES.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU LONG LIST CONSULT TITLES",
     "desc": "This RPC serves data to a longlist of selectable TITLES for CONSULTS.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU LONG LIST OF TITLES",
     "desc": "This RPC serves data to a longlist of selectable TITLES by CLASS.  e.g.,passing the class PROGRESS NOTES will return active Progress Notes titleswhich the current user is authorized to enter notes under.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU LONG LIST SURGERY TITLES",
     "desc": "This RPC serves data to a longlist of selectable TITLES for the classnamed in the CLNAME parameter.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU PERSONAL TITLE LIST",
     "desc": "This Remote Procedure returns the user’s list of preferred titles for agiven class of documents, along with the default title, if specified.",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU TEMPLATE LISTOWNR",
     "desc": "",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU USER CLASS LONG LIST",
     "desc": "Long List of User Classes",
     "category": "mvdm-read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "DG SENSITIVE RECORD BULLETIN",
     "desc": "This Remote Procedure Call (RPC) will add an entry to the DG SECURITY LOG(#38.1) file and/or generate the sensitive record access bulletindepending on the value in ACTION input parameter.  If ACTION parameter notdefined, defaults to update DG Security Log file and generate SensitiveRecord Access mail message.",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "GMV ADD VM",
     "desc": "This remote procedure call is used to enter a new Vital/Measurement recordin the GMRV Vital Measurement file (#120.5). This remote procedure call is documented in Integration Agreement 3996.",
     "category": "mvdm-write",
-    "locked": true
+    "emulated": true
   },
   {
     "name": "GMV MARK ERROR",
     "desc": "This remote procedure call marks a selected vitals record in the GMRVVital Measurement (#120.5) file as entered-in-error. This remote procedure call is documented in Integration Agreement 4414.",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORB DELETE ALERT",
     "desc": "This function deletes an alert.",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN ADDCMT",
     "desc": "Allows addition of a comment to a consult request/consult without changingits status. Optionally, allows sending of an alert to the requestingprovider and others.",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN REMOVE MED RESULTS",
     "desc": "Allows removal of medicine results from a  procedure.",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN2 SAVE CONTEXT",
     "desc": "",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPL ADD SAVE",
     "desc": "Add new problem record",
     "category": "mvdm-write",
-    "locked": true
+    "emulated": true
   },
   {
     "name": "ORQQPL DELETE",
     "desc": "DELETES A PROBLEM",
     "category": "mvdm-write",
-    "locked": true
+    "emulated": true
   },
   {
     "name": "ORQQPL EDIT SAVE",
     "desc": "sAVES EDITED PROBLEM RECORD",
     "category": "mvdm-write",
-    "locked": true
+    "emulated": true
   },
   {
     "name": "ORQQPL REPLACE",
     "desc": "REPLACES A PROBLEM THAT WAS PREVIOUSLY DELETED",
     "category": "mvdm-write",
-    "locked": true
+    "emulated": true
   },
   {
     "name": "ORQQPL SAVEVIEW",
     "desc": "Saves preferred view (inpatient/outpatient) and list of preferredclinics/services to NEW PERSON file, field 125.nn.  Also sets value ofparameter [ORCH CONTEXT PROBLEMS], which controls the default status ofthe problems shown, as well as whether comments should be displayed.Preferences take effect for both GUI and List Manager, and can be changedfrom either interface.",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPL UPDATE",
     "desc": "Updates problem record",
     "category": "mvdm-write",
-    "locked": true
+    "emulated": true
   },
   {
     "name": "ORQQPX SAVELVL",
     "desc": "Saves Parameter Level settings.",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPXRM MENTAL HEALTH SAVE",
     "desc": "Stores test result responses from a reminder dialog.",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPXRM MST UPDATE",
     "desc": "Saves MST data",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPXRM WOMEN HEALTH SAVE",
     "desc": "Pass back data to be file in the Women’s Health Package file 790.1.",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWCH SAVEALL",
     "desc": "This RPC saves the sizing related CPRS GUI chart parameters for theuser.",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWCH SAVECOL",
     "desc": "This RPC saves the column width sizes for reports in CPRS for the user.",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWCH SAVESIZ",
     "desc": "This RPC saves the size (bounds) for a particular CPRS GUI control.",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWCIRN WEBADDR",
     "desc": "Get VistaWeb Web Address.",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWD SAVE",
     "desc": "Saves an order.  The order is passed in ORDIALOG format.",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWD SAVEACT",
     "desc": "Saves the action on a order in an unsigned/unreleased state.",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDAL32 SAVE ALLERGY",
     "desc": "",
     "category": "mvdm-write",
-    "locked": true
+    "emulated": true
   },
   {
     "name": "ORWDBA2 ADDPDL",
     "desc": "Add a new Clinician’s Personal DX List or add new ICD9 codes to an existing Clinician’s Personal DX List. The Personal DX list is stored in the CPRS Diagnosis Provider file, file # 5000017",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDFH ADDLATE",
     "desc": "RPC to add a late tray diet order.",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS33 GETADDFR",
     "desc": "This RPC takes an Additive Orderable ITEM IEN and it returns the defaultadditive frequency defined to the additive file.",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDX SAVE",
     "desc": "Save the order by passing in the following information:        ORVP=DFN        ORNP=Provider        ORL=Location        DLG=Order Dialog,        ORDG=Display Group        ORIT=Quick Order Dialog,        ORIFN=null if new order        ORDIALOG=Response List",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXC SAVECHK",
     "desc": "Save order checks for session.",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXQ DLGSAVE",
     "desc": "Return IEN of new or existing quick order.",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE DELETE",
     "desc": "Delete PCE information related to a note being deleted.",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE SAVE",
     "desc": "Saves PCE information entered into CPRS GUI.",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE SAVEGAF",
     "desc": "Saves a GAF Score.",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWSR SAVE SURG CONTEXT",
     "desc": "",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTIU GET SAVED CP FIELDS",
     "desc": "Given a TIU document of the clinical procedures class, return the author, title, cosigner, procedure summary code, date/time of procedure, and reference date, as stored on the server.",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTIU SAVE DCSUMM CONTEXT",
     "desc": "",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTIU SAVE TIU CONTEXT",
     "desc": "",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP ADDLIST",
     "desc": "",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP SAVECD",
     "desc": "",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP SAVECS",
     "desc": "",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP SAVELIST",
     "desc": "",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP SAVENOT",
     "desc": "",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP SAVENOTO",
     "desc": "",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP SAVEOC",
     "desc": "",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP SAVEPLD",
     "desc": "",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP SAVESURR",
     "desc": "",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP SAVET",
     "desc": "",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU CREATE ADDENDUM RECORD",
     "desc": "This Remote Procedure allows the creation of addenda to TIU Documents.",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU CREATE RECORD",
     "desc": "This remote procedure allows the creation of TIU DOCUMENT records.",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU DELETE RECORD",
     "desc": "Deletes TIU Document records…Evaluates authorization.",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU FIELD DELETE",
     "desc": "Deletes an entry in the Template Field (8927.1) file.",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU FIELD LIST ADD",
     "desc": "Takes in the XML string, in the format XMLSET(1)=” ",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU FIELD SAVE",
     "desc": "Saves a single Template Field",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU GET ADDITIONAL SIGNERS",
     "desc": "Returns the list of additional signers currently identified for a givenTIU document.",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU JUSTIFY DELETE?",
     "desc": "BOOLEAN RPC that evaluates wheter a justification is required for deletion (e.g., deletion is authorized, but the document has been signed, etc.).",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU TEMPLATE CREATE/MODIFY",
     "desc": "This remote procedure allows creation and update of Templates.",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU TEMPLATE DELETE",
     "desc": "This RPC will delete orphan entries in the Template file (i.e., onlythose entries that have been removed from any Groups, Classes, Personalor Shared Root entries).",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU UPDATE ADDITIONAL SIGNERS",
     "desc": "This RPC accepts a list of persons, and adds them as additional signersfor the document identified by the first parameter.",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU UPDATE RECORD",
     "desc": "This API updates the record named in the TIUDA parameter, with theinformation contained in the TIUX(Field #) array.  The body of themodified TIU document should be passed in the TIUX(“TEXT”,i,0) subscript,where i is the line number (i.e., the “TEXT” node should be ready to MERGEwith a word processing field).  Any filing errors which may occur will bereturned in the single valued ERR parameter (which is passed byreference).",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU WAS THIS SAVED?",
     "desc": "This Boolean Remote Procedure will evaluate whether a given document wascommitted to the database, or whether the user who last edited it wasdisconnected.",
     "category": "mvdm-write",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORB FOLLOW-UP TYPE",
     "desc": "Returns the follow-up action type for a notification as identified via thealert xqaid.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORB SORT METHOD",
     "desc": "Returns the default sort method for notification display based on the precedence USER, DIVISION, SYSTEM, PACKAGE.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORDEA DEATEXT",
     "desc": "Returns the text to show on the signature dialog mandated by DEA for when a controlled substance order is selected to be signed.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORDEA LNKMSG",
     "desc": "Returns the text of the OR DEA PIV LINK MSG parameter.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORPRF TRIGGER POPUP",
     "desc": "Returns 1 if popup flag display should be triggered for given patient uponpatient selection. If not, returns 0. Does not require clean-up aftercalling it since it does not set arrays or globals.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQORB SORT",
     "desc": "Returns the notification sort method for user/division/system/pkg.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQPT ATTENDING/PRIMARY",
     "desc": "Returns a patient’s attending physician and primary provider.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQPT CLINIC PATIENTS",
     "desc": "Returns patients with appointments at a clinic between start and stop dates",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQPT DEFAULT CLINIC DATE RANG",
     "desc": "Returns default start and stop dates for clinics in the form: start^stop.Start and stop are free text and are not in FM format.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQPT WARDRMBED",
     "desc": "Returns the ward, room-bed for a patient.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN ASSIGNABLE MED RESULTS",
     "desc": "Returns a list of medicine results that can be attached to a procedure.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN CANEDIT",
     "desc": "Returns indication of whether a consult/procedure request can beresubmitted.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN EDIT DEFAULT REASON",
     "desc": "Return value (see details there) determines if and when the consults’reason for request’ can be edited.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN MED RESULTS",
     "desc": "Returns a display of Medicine Package results, followed by any TIUresults.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN REMOVABLE MED RESULTS",
     "desc": "Returns list of medicine results that are currently attached to aprocedure.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN SHOW SF513",
     "desc": "Returns text of consults standard form 513 for display in GUI application.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN STATUS",
     "desc": "Returns a list of consult statuses currently in use, as reflected in the”AC” XREF of ^GMR(123.1.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN SVCTREE",
     "desc": "Returns a specially formatted list of consult services for use inpopulating a GUI TreeView control.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN UNRESOLVED",
     "desc": "Returns 1 if current user has unresolved consults for current patient, 0 if not.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN URGENCIES",
     "desc": "Returns a list of applicable urgencies from PROTOCOL file 101,given a ConsultIEN and type.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN2 GET PREREQUISITE",
     "desc": "Returns resolved boilerplate form CONSULT SERIVCES file (123.5) reflectingthe service’s prerequisites for ordering a consult.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQLR SEARCH RANGE INPT",
     "desc": "Returns the date search range in number of days (e.g. 2) to begin the search before today. For example, a value of 2 would indicate to limit thesearch between two days and today. Limited to inpatients.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQLR SEARCH RANGE OUTPT",
     "desc": "Returns the date search range in number of days (e.g. 90) to begin the search before today.  For example, a value of 90 would indicate to limit thesearch between ninety day. Limited to Outpatients.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPL CLIN SRCH",
     "desc": "Returns list of clinics for problem list. Should be replaced by CLIN^ORQPT",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPL EDIT LOAD",
     "desc": "Return array of default fields and original fields - GMPFLD() and GMPORIG()",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPL INIT USER",
     "desc": "Returns user parameters for problem list",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPL PROB COMMENTS",
     "desc": "Returns a list of comments associated with a problem IEN.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPX GET DEF LOCATIONS",
     "desc": "Returns the contents of the ORQQPX DEFAULT LOCATIONS parameter.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPX GET FOLDERS",
     "desc": "Returns the value of the ORQQPX REMINDER FOLDERS parameter for thecurrent user.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPX GET HIST LOCATIONS",
     "desc": "Returns a list of historical locations from the LOCATION file(#9999999.06).",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPX LVREMLST",
     "desc": "Returns Cover Sheet reminder settings",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPX NEW COVER SHEET ACTIVE",
     "desc": "Returns TRUE if the new cover sheet parameters are to be used.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPX NEW COVER SHEET REMS",
     "desc": "Returns a list of reminders for cover sheet evaluation.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPX NEW REMINDERS ACTIVE",
     "desc": "Return 1 if Interactive Reminders are active, otherwise return 0.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPX REM INSERT AT CURSOR",
     "desc": "Returns TRUE if text generated from a reminder dialog, when processinga reminder, is to be inserted at the current cursor location, ratherthan at the bottom of the note.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPXRM EDUCATION SUBTOPICS",
     "desc": "Returns array of subtopics for any given education topic",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPXRM EDUCATION SUMMARY",
     "desc": "Returns list of education topics for a reminder",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPXRM GET WH LETTER TEXT",
     "desc": "Retrieve letter text for a WH letter",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPXRM GET WH LETTER TYPE",
     "desc": "Return value from file 790.403",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPXRM GET WH PROC RESULT",
     "desc": "Return correct values for a WH procedure populate a combo box in ReminderDialog.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPXRM MENTAL HEALTH",
     "desc": "Returns array for given mental health instrument",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPXRM MENTAL HEALTH RESULTS",
     "desc": "Returns progress note text based on the results of the test.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPXRM PROGRESS NOTE HEADER",
     "desc": "Returns header text to be inserted in each progress note.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPXRM REMINDER CATEGORIES",
     "desc": "Returns list of all CPRS lookup categories and associated reminders",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPXRM REMINDER EVALUATION",
     "desc": "Allows evaluation of a list of reminders. Returns a list of clinicalreminders due/applicable or not applicable to the patient.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPXRM REMINDERS APPLICABLE",
     "desc": "Returns a list of clinical reminders due/applicable or not applicable tothe patient.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPXRM REMINDERS UNEVALUATED",
     "desc": "Returns list of CPRS reminders for patient/location (no evaluation isdone)",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQVS VISITS/APPTS",
     "desc": "Returns a list of patient appointments and visits for a date/time range.location.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQXMB MAIL GROUPS",
     "desc": "Returns mail groups in a system.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORVAA VAA",
     "desc": "Returns the policy name for a veteran with VA Advantage. If the veteran does not have VA Advantage the return value will be 0.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWCOM GETOBJS",
     "desc": "Returns a list of all active COM objects",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWCOM ORDEROBJ",
     "desc": "Returns COM Objects for order accept",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWCOM PTOBJ",
     "desc": "Returns COM Object entries from  different parameters.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWCV LAB",
     "desc": "Returns a list of labs to display on the CPRS GUI cover sheet for apatient.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWD DEF",
     "desc": "Returns the formatting definition for an ordering dialog from the ORDERDIALOG file (101.41).",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWD DT",
     "desc": "Returns a date in internal Fileman format.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWD FORMID",
     "desc": "Returns the Form ID (mapping to a windows form) for an ordering dialog.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWD GET4EDIT",
     "desc": "Returns the responses for an already existing order.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWD OI",
     "desc": "Returns a group of orderable items to be used in the OnNeedData event fora long list box.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWD PROVKEY",
     "desc": "Returns 1 if the users possesses the PROVIDER key.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWD VALIDACT",
     "desc": "Returns 1 if action is valid for an order, otherwise 0^error.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWD1 COMLOC",
     "desc": "Returns true if all orders in a list have a common ordering location.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWD1 PARAM",
     "desc": "Returns the prompt and device parameters for Automated order prints",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWD1 SIG4ANY",
     "desc": "Returns true if any orders in the list require a signature.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWD1 SIG4ONE",
     "desc": "Returns true if an order requires a signature.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWD2 DEVINFO",
     "desc": "Returns device information related to a location/nature of order when anorder is signed or released via CPRS GUI.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWD2 MANUAL",
     "desc": "Returns device information for manual prints done via CPRS GUI.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDAL32 DEF",
     "desc": "Returns default values and list sets for Allergy ordering dialog.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDBA1 BASTATUS",
     "desc": "Billing Awareness RPC.Returns 0 if BA functionality is off or 1 if BA functionality is on.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDBA2 GETPDL",
     "desc": "Returns a clinician’s personal diagnosis codes.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDBA3 HINTS",
     "desc": "Returns an array of ‘Hints’ for Treatment Factors for CPRS CI/BA Project.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDCN32 NEWDLG",
     "desc": "Returns dialog information when NEW CONSULT/PROCEDURE is selected fromthe consults tab.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDCN32 PROCEDURES",
     "desc": "Returns a list of orderable procedures.  Same as ORDITM^ORWDX except: 1.  Checks inactive date in file 101.43 against NOW instead of DT.2.  Checks for at least one service that can perform the procedure.3.  Returns variable pointer to procedure in 4th piece of each item.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDFH CURISO",
     "desc": "Return a patient’s current isolation.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDFH DIETS",
     "desc": "Returns active diets (including NPO) in the format:      IEN^NAME   or IEN^SYNONYM ",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDFH FINDTYP",
     "desc": "Return type of dietetics order based on display group.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDFH ISOIEN",
     "desc": "Returns the IEN for the Isolation/Precaution orderable item.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDFH NFSLOC READY",
     "desc": "Return ‘1’ if hospital location has been entered in NUTRITION LOCATION file for outpatient meal ordering.Return ‘0’ if not yet entered.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDFH PARAM",
     "desc": "Returns dietetics parameters for a patient at a location.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDFH QTY2CC",
     "desc": "Returns cc’s given a product, strength, and quantity.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDFH TFPROD",
     "desc": "Returns a list of active tubefeeding products.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDLR ABBSPEC",
     "desc": "Returns lab specimens that have an abbreviation (used as default list).",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDLR ALLSAMP",
     "desc": "Returns a list of collection samples for a lab order.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDLR32 ABBSPEC",
     "desc": "Returns a list of lab specimens with abbreviations.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDLR32 ALLSAMP",
     "desc": "Returns all collection samples in the format:   n^SampIEN^SampName^SpecPtr^TubeTop^^^LabCollect^^SpecName",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDLR32 ALLSPEC",
     "desc": "Returns a list of specimens from the TOPOGRAPHY FIELD file (#61).",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDLR32 GET LAB TIMES",
     "desc": "Returns a list of lab collect times for a date and location.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDLR32 IC DEFAULT",
     "desc": "Returns default immediate collect time for the user’s division.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDLR32 IMMED COLLECT",
     "desc": "Returns help text showing lab immediate collect times for the user’sdivision.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDLR32 LOAD",
     "desc": "Return sample, specimen, &amp; urgency info about a lab test.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDLR32 MAXDAYS",
     "desc": "Returns the maximum number of days for a continuous lab order.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDLR32 ONE SAMPLE",
     "desc": "Returns data for one collection sample in the format:     n^SampIEN^SampName^SpecPtr^TubeTop^^^LabCollect^^SpecName",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDLR32 ONE SPECIMEN",
     "desc": "Returns IEN^NAME of requested a TOPOGRAPHY FIELD (file #61) entry.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDLR32 STOP",
     "desc": "Returns a calculated stop date for a lab order.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDLR33 FUTURE LAB COLLECTS",
     "desc": "Returns the number of days in the future to allow Lab Collects.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDOR VMSLCT",
     "desc": "Returns the default list for the vitals order dialog in CPRS GUI.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS32 ALLROUTE",
     "desc": "Returns a list of all available medication routes.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS32 DLGSLCT",
     "desc": "Returns default lists for order dialogs in CPRS GUI.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS32 DOSES",
     "desc": "Return doses for an orderable item.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS32 DRUGMSG",
     "desc": "Return message text that is associated with a dispense drug.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS32 FORMALT",
     "desc": "Return a list of formulary alternatives.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS32 ISSPLY",
     "desc": "Return 1 if orderable item is a supply, otherwise return 0.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS32 IVAMT",
     "desc": "Returns return UNITS^AMOUNT |^AMOUNT^AMOUNT…| for IV solutions.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS32 MEDISIV",
     "desc": "Return 1 if orderable item is an IV medication, otherwise return 0.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS32 OISLCT",
     "desc": "Returns defaults for pharmacy orderable items.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS32 SCSTS",
     "desc": "Return pharmacy-related service connected eligibility for a patient.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS32 VALRATE",
     "desc": "Return a 1 if IV rate text is valid, otherwise return 0.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS32 VALROUTE",
     "desc": "Returns the IEN for a route if the name is valid.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDX AGAIN",
     "desc": "Returns a 1 if the dialog should be kept for another order, otherwise 0.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDX DGRP",
     "desc": "Returns the display group pointer for an order dialog.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDX DISMSG",
     "desc": "Returns disabled message for an ordering dialog.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDX DLGDEF",
     "desc": "Return format information for an order dialog in the format:   LST(n): PrmtID^PrmtIEN^FmtSeq^Fmt^Omit^Lead^Trail^NwLn^Wrap^Chld^IsChld",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDX DLGID",
     "desc": "Returns the dialog IEN for an order.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDX DLGQUIK",
     "desc": "Return responses for a quick order (no longer used).",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDX FORMID",
     "desc": "Returns the base dialog FormID for an order.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDX MSG",
     "desc": "Return message text for an orderable item.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDX ORDITM",
     "desc": "Returns an array of orderable items in the format:   Y(n)=IEN^.01 Name^.01 Name  -or-  IEN^Synonym &lt;.01 Name&gt;^.01 Name",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDX WRLST",
     "desc": "Return list of dialogs for writing orders in format:        Y(n)=DlgName^ListBox Text",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXA DCREQIEN",
     "desc": "Return the IEN for Requesting Physician Cancelled reason.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXA FLAGTXT",
     "desc": "Return text associated with a particular flagged order (reason for flag).",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXA VALID",
     "desc": "Returns an error message if the selected action is not valid for aparticular CPRS GUI order.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXA WCGET",
     "desc": "Return ward comments for an order.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXC ACCEPT",
     "desc": "Return list of Order Checks on Accept Order.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXC DELAY",
     "desc": "Return list or order checks on accept delayed orders.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXC DISPLAY",
     "desc": "Return list of Order Checks for a FillerID (namespace).",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXC FILLID",
     "desc": "Return the FillerID (namespace) for a dialog.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXC ON",
     "desc": "Returns E if order checking enabled, otherwise D.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXC SESSION",
     "desc": "Return list of order checks on release of order.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXM DLGNAME",
     "desc": "Return name(s) of dialog &amp; base dialog given IEN in format:        VAL=InternalName^DisplayName^BaseDialogIEN^BaseDialogName",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXM FORMID",
     "desc": "Return the FormID for a dialog entry.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXM LOADSET",
     "desc": "Return the contents of an order set in the following format:   LST(0): SetDisplayText^Key Variables   LST(n): DlgIEN^DlgType^DisplayText",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXM MENU",
     "desc": "Returns menu contents for an order dialog in the following format:    LST(0)=name^# cols^path switch^^^ Key Variables (pieces 6-20)    LST(n)=col^row^type^ien^formid^autoaccept^display text^mnemonic           ^displayonly",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXM MSTYLE",
     "desc": "Return the menu style for the system.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXM PROMPTS",
     "desc": "Return prompting information for a generic dialog in the format:    LST(n)=ID^REQ^HID^PROMPT^TYPE^DOMAIN^DEFAULT^IDFLT^HELP",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXQ DLGNAME",
     "desc": "Return display name for a dialog.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXQ GETQLST",
     "desc": "Return quick list for a display group.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXQ GETQNAM",
     "desc": "Return current quick order name.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXR ISREL",
     "desc": "Return 1 if an order has been released, otherwise return 0.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXR RNWFLDS",
     "desc": "Return fields for renew action in format:    LST(0)=RenewType^Start^Stop^Refills^Pickup  LST(n)=Comments",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXVB GETALL",
     "desc": "Return patient’s Blood Bank information.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXVB RAW",
     "desc": "Return raw Lab Test Results associated with Blood Bank orderrequest.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXVB RESULTS",
     "desc": "Return patient’s Lab Test Results associated with Blood Bank orderrequest.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWGN IDTVALID",
     "desc": "Returns the implementation date of the coding system passed in",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWLRR INFO",
     "desc": "Return lab test description information.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWOR EXPIRED",
     "desc": "Returns the Fileman Date/Time to begin searching for expired orders.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWOR RESULT",
     "desc": "Returns results of a CPRS order.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWOR RESULT HISTORY",
     "desc": "Returns a result history of a CPRS order.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWOR SHEETS",
     "desc": "Returns order sheets for a patient.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWOR TSALL",
     "desc": "Returns a list of valid treating specialities.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWOR UNSIGN",
     "desc": "Returns outstanding unsigned orders.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWOR VWGET",
     "desc": "Retrieves the user’s default view for the orders tab.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWOR1 CHKDIG",
     "desc": "Returns true if an order requires a digital signature.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWOR1 GETDEA",
     "desc": "Returns a users DEA number.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWOR1 GETDSCH",
     "desc": "Returns the schedule of the drug.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWOR1 GETDSIG",
     "desc": "Returns the digital signature of an existing order.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWOR1 GETDTEXT",
     "desc": "Returns the external text of an existing order.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWOR1 SIG",
     "desc": "Returns 1 if signature gets stored.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWORB GETSORT",
     "desc": "Returns the method for sorting GUI alert display.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWORB TEXT FOLLOWUP",
     "desc": "Returns text for notifications/alerts with a simple text message follow-upaction.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWORDG ALLTREE",
     "desc": "Returns the tree for all display groups.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWORDG GRPSEQB",
     "desc": "Returns expanded list of display groups.for the current site/user.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWORDG IEN",
     "desc": "Returns IEN of a display group.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWORDG REVSTS",
     "desc": "Returns the status flags available for review orders action.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWORR GET",
     "desc": "Returns a list of orders &amp; and associated fields and text.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWORR GET4LST",
     "desc": "Returns the order fields for a list of orders.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWORR GETBYIFN",
     "desc": "Returns the fields for a single order in the format:       1   2    3     4      5     6   7   8   9   10     11    12 .LST=~IFN^Grp^ActTm^StrtTm^StopTm^Sts^Sig^Nrs^Clk^PrvID^PrvNam^ActDA",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWORR GETTXT",
     "desc": "Returns the text of an existing order.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE ACTIVE PROV",
     "desc": "This calls the PCE API $$ACTIVPRV^PXAPI(provider ien, encounter d/t) tosee if the provider can be stored by PCE.   Returns a 1 if provider is good and 0 if the provider is not active or does not have an active person class.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE ALWAYS CHECKOUT",
     "desc": "Returns TRUE if encounters should be automatically checked out.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE ANYTIME",
     "desc": "Returns TRUE if encounters can be entered at any time",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE ASKPCE",
     "desc": "Returns the value of the ORWPCE ASK ENCOUNTER UPDATE parameter.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE AUTO VISIT TYPE SELECT",
     "desc": "Returns TRUE if visit type should be automatically selected.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE CPTMODS",
     "desc": "Returns a list of CPT Modifiers for a given CPT Code.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE CPTREQD",
     "desc": "Returns 1 if TIU DOCUMENT file entry needs a CPT code.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE DIAG",
     "desc": "Returns a list of diagnosis codes for a clinic location.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE FORCE",
     "desc": "Returns the value of the ORWPCE FORCE GUI PCE ENTRY parameter.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE GAFOK",
     "desc": "Returns TRUE if supporting mental health code exists to read and writeGAF scores.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE GAFURL",
     "desc": "Returns the GAF Scale Rating Form URL",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE GET EDUCATION TOPICS",
     "desc": "Returns a list of active education topics.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE GET EXAM TYPE",
     "desc": "Returns the list of active exam types.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE GET EXCLUDED",
     "desc": "Returns a list of excluded PCE entries",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE GET HEALTH FACTORS TY",
     "desc": "Returns a list of active health factor types.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE GET IMMUNIZATION TYPE",
     "desc": "Returns a list of active immunizations.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE GET SET OF CODES",
     "desc": "Returns values for a set of codes given a file and field number.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE GET SKIN TEST TYPE",
     "desc": "Returns a list of the active skin test codes.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE GET TREATMENT TYPE",
     "desc": "Returns the list of active treatments.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE GET VISIT",
     "desc": "Returns the visit IEN.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE GETMOD",
     "desc": "Returns information for a specific CPT Code.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE HASCPT",
     "desc": "Returns the passed array with the second piece set to 0 or 1.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE HASVISIT",
     "desc": "Returns the visit status of the visit associated with a note:1 if the visit is being pointed to by an appointment0 if the visit is NOT being pointed to by an appointment-1 if the visit is invalid or could not be determined",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE HF",
     "desc": "Returns a list of health factors for a clinic.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE HNCOK",
     "desc": "Returns TRUE if the Head and/or Neck Cancer patches have been installed",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE ICDVER",
     "desc": "Returns the ICD coding system version to be used for diagnosis look-up, asof a particular date of interest.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE IMM",
     "desc": "Returns a list of immunizations for a clinic.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE ISCLINIC",
     "desc": "Returns TRUE if location is a Clinic.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE LEX",
     "desc": "Returns list based on lexicon look-up.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE LEXCODE",
     "desc": "Returns a code associated with a lexicon entry.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE LOADGAF",
     "desc": "Returns a list of GAF Scores",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE MHCLINIC",
     "desc": "Returns TRUE of the indicated clinic is a mental health clinic.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE MHTESTOK",
     "desc": "Returns TRUE if all supporing code is in place for Mental Health Tests.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE NOTEVSTR",
     "desc": "Returns VISIT LOCATION;EPISODE BEGIN DATE;VISIT TYPE from the TIU DOCUMENTfile.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE PCE4NOTE",
     "desc": "Returns the encounter information for an associated note in the format: LST(1)=HDR^AllowEdit^CPTRequired^VStr^Author^hasCPTLST(n)=TYP+^CODE^CAT^NARR^QUAL1^QUAL2 (QUAL1=Primary!Qty, QUAL2=Prv)",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE PED",
     "desc": "Returns list of education topics for a clinic.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE PROC",
     "desc": "Returns a list of procedures for a clinic location.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE SCDIS",
     "desc": "Returns service connected percentage and rated disabilities for a patient.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE SCSEL",
     "desc": "Returns a list of service connected conditions that may be selected.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE SK",
     "desc": "Returns a list of skin tests for a clinic.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE TRT",
     "desc": "Returns a list of treatments for a clinic.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE VISIT",
     "desc": "Returns a list of visit types for a clinic.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE XAM",
     "desc": "Returns a list of exams for a clinic.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE4 LEX",
     "desc": "Returns list of coded elements based on lexicon look-up. Introduced with CPRS v29 to maintain compatibility of older call ORWPCE LEX.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPS ACTIVE",
     "desc": "Returns listing of a patient’s active inpatient and outpatientmedications.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPS COVER",
     "desc": "Returns a list of medications to display on the CPRS GUI cover sheet for apatient.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPS REASON",
     "desc": "Returns list of Statement/Reasons for Non-VA medication orders.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPS1 NEWDLG",
     "desc": "Returns order dialog information for a new medication.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPS1 PICKUP",
     "desc": "Returns default for refill location (mail or window).",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPT ADMITLST",
     "desc": "Returns a list of admissions for a patient (for visit selection).",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPT APPTLST",
     "desc": "Returns a list of appointments for a patient (for visit selection).",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPT BYWARD",
     "desc": "Returns a list of patients currently residing on a specified wardlocation.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPT CLINRNG",
     "desc": "Returns a list of selectable options from which a user can choose a daterange for appointments.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPT CWAD",
     "desc": "Returns the CWAD flag(s) for a patient.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPT DFLTSRC",
     "desc": "Return user’s default patient list source.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPT DIEDON",
     "desc": "Returns date of death if patient has expired.  Otherwise returns 0.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPT ENCTITL",
     "desc": "Returns external values to display for encounter in format:     LOCNAME^LOCABBR^ROOMBED^PROVNAME",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPT INPLOC",
     "desc": "Returns the patient’s current location if an inpatient.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPT LAST5",
     "desc": "Returns a list of patients matching the string of Last Name Initial_Last 4SSN (Initial/Last 4 look-up to PATIENT file).",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPT LAST5 RPL",
     "desc": "Returns a list of patients matching the string of Last Name Initial_Last 4 SSN (Initial/Last 4 look-up based on Restricted Patient List).",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPT LEGACY",
     "desc": "Returns message if patient has data on a legacy system.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPT SELCHK",
     "desc": "Returns a 1 if the patient record is flagged as senstive, otherwisereturns 0.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPT TOP",
     "desc": "Returns the last selected patient by the defined user.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPT1 PRCARE",
     "desc": "Return primary care information for a patient in the format:  VAL=Primary Care Team^Primary Care Provider^Attending^MH Treatment      Coordinator",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTIU IDNOTES INSTALLED",
     "desc": "Returns “1” if TIU",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWU CLINLOC",
     "desc": "Returns a list of clinics from the HOSPITAL LOCATION file (#44).",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWU DEFAULT DIVISION",
     "desc": "Returns True or False for a user depending on default division information.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWU DEVICE",
     "desc": "Returns a list of print devices.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWU DT",
     "desc": "Returns date in internal VA FileMan format.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWU EXTNAME",
     "desc": "Returns the external form of a pointer value given the IEN and filenumber.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWU GBLREF",
     "desc": "Returns the global reference for a particular file number.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWU GENERIC",
     "desc": "Returns a list of entries from a cross-reference passed in.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWU HAS OPTION ACCESS",
     "desc": "Returns true if the user has access to the specified menu option.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWU HASKEY",
     "desc": "Returns 1 if a user holds a security key, otherwise 0.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWU HOSPLOC",
     "desc": "Returns a set of hospital locations for use in a long list box.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWU INPLOC",
     "desc": "Returns a list of wards from the HOSPITAL LOCATION file.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWU NEWPERS",
     "desc": "Returns a set of New Person file entries for use in a long list box.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWU NPHASKEY",
     "desc": "Returns a 1 if a specified user holds a specified key, otherwise returns0.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWU PATCH",
     "desc": "Returns a 1 if the specified patch is installed on the system, otherwisereturns a 0.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWU TOOLMENU",
     "desc": "Returns a list of items for the CPRS GUI Tools menu.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWU USERINFO",
     "desc": "Returns preferences for the current user.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWU VERSION",
     "desc": "Returns current version of package or namespace",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWU VERSRV",
     "desc": "Returns the server version of a particular option.  This is specificallyused by CPRS GUI to determine the current server version of the associatedsoftware.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWU1 NEWLOC",
     "desc": "Returns a list of Clinics, Wards, and “Other” category entries from the HOSPITAL LOCATION (#44) file.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWU16 USERINFO",
     "desc": "Returns information about the current user in the format:     DUZ^NAME^USRCLS^CANSIGN^ISPROVIDER^ORDERROLE^NOORDER^DTIME^CD",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWU2 COSIGNER",
     "desc": "Returns a set of New Person file entries for use in a long list box.The set is limited to USR PROVIDERS who do not require cosignature.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWUH POPUP",
     "desc": "Retrieves the “What’s This” text for a given control.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWUX SYMTAB",
     "desc": "Returns the contents of the current session’s symbol table.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "PXRM REMINDERS AND CATEGORIES",
     "desc": "Returns list of reminders and categories.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU DIV AND CLASS INFO",
     "desc": "Returns a list of Divisions and User Classes for a specific User.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU DOCUMENTS BY CONTEXT",
     "desc": "Returns lists of TIU Documents that satisfy the following search criteria: 1 - signed documents (all)   2 - unsigned documents  3 - uncosigned documents4 - signed documents/author5 - signed documents/date range",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU FIELD CAN EDIT",
     "desc": "Returns TRUE if the current user is allowed to edit template fields.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU FIELD LOAD",
     "desc": "Returns a single Template Field object",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU FIELD LOAD BY IEN",
     "desc": "Returns a single Template Field object.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU FIELD NAME IS UNIQUE",
     "desc": "Returns TRUE if the template field name is unique",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU GET BOILERPLATE",
     "desc": "Returns a titles boilerplate.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU GET DS URGENCIES",
     "desc": "Returns a set of discharge summary urgencies for use in a long list box.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU GET LINKED PRF NOTES",
     "desc": "Returns list of SIGNED, LINKED PRF notes for given patient, for givenPRF Title",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU GET PERSONAL PREFERENCES",
     "desc": "Returns Users personal preferences for TIU in the following format: TIUY = USER [1P] ^ DEFAULT LOCATION [2P] ^ REVIEW SCREEN SORT FIELD [3S] ^    ==&gt;REVIEW SCREEN SORT ORDER [4S] ^ DISPLAY MENUS [5S] ^ PATIENT    ==&gt;SELECTION PREFERENCE [6S] ^ ASK ‘Save changes?’ AFTER EDIT [7S] ^    ==&gt;ASK SUBJECT FOR PROGRESS NOTES [8S] ^",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU GET PRF TITLE",
     "desc": "Returns IEN of the TIU Note Title in file 8925.1 which is associatedwith given flag for given patient.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU HAS AUTHOR SIGNED?",
     "desc": "Boolean RPC returns a value of 0 if the author has not signed and the user attempting to sign is the expected co-signer.  Returns a 1 if the author has signed or the user attempting to sign is NOT the expected co-signer.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU REM DLG OK AS TEMPLATE",
     "desc": "Returns TRUE is the passed in reminder dialog is allowed to be used ina TIU Template.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU REMINDER DIALOGS",
     "desc": "Returns a list of reminder dialogs allowed for use as Templates.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU TEMPLATE ALL TITLES",
     "desc": "Returns a long list of all active titles.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU TEMPLATE GET DEFAULTS",
     "desc": "Returns Default Template Settings",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU TEMPLATE GET DESCRIPTION",
     "desc": "Returns a Template’s Description",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU TEMPLATE GETLINK",
     "desc": "Returns template linked to a specific title or reason for request.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU TEMPLATE PERSONAL OBJECTS",
     "desc": "Returns a list or Patient Data Objects allowed in Personal Templates.",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU USER INACTIVE?",
     "desc": "RPC evaluates user’s DIUSER status and termination status when selected.Returns 0 if active        1 if inactive",
     "category": "read",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "DG CHK BS5 XREF ARRAY",
     "desc": "CHECKS IF OTHER PATIENTS ON ‘BS5’ XREF WITH SAME LAST NAMERETURN 1 OR 0 IN 1ST STRING (-1 IF BAD DFN OR NO ZERO NODE).RETURNS ARRAY NODES WHERE TEXT IS PRECEEDED BY 0 AND PATIENT DATAIS PRECEEDED BY 1.  PATIENT DATA WILL BE IN FOLLOWING FORMAT: 1^DFN^PATIENT NAME^DOB^SSN",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "DG CHK BS5 XREF Y/N",
     "desc": "CHECKS IF OTHER PATIENTS ON “BS5” XREF WITH SAME LAST NAMERETURNS 1 OR 0 IN 1ST STRING (OR -1 IF BAD DFN OR NO ZERO NODE)IF 1 RETURNS TEXT TO BE DISPLAYED",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "DG CHK PAT/DIV MEANS TEST",
     "desc": "CHECKS IF MEANS TEST REQUIRED FOR PATIENT ANDCHECKS IF MEANS TEST DISPLAY REQUIRED FOR USER’S DIVISIONRETURNS 1 IN 1ST STRING IF BOTH TRUE OTHERWISE 0IF BOTH TRUE RETURNS TEXT IN 2ND AND 3RD STRING (IF ANY)",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "MAG4 REMOTE IMPORT",
     "desc": "Called from MS Windows Application.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORALWORD ALLWORD",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORB FOLLOW-UP ARRAY",
     "desc": "This function returns an array of follow-up data.  Content of the datavaries by notification.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORB FOLLOW-UP STRING",
     "desc": "This function returns a string of follow-up data.  Content of the data varies by notification.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORB FORWARD ALERT",
     "desc": "The rpc forwards an alert.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORB RENEW ALERT",
     "desc": "This rpc renews an alert.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORBCMA5 GETUDID",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORCDLR2 CHECK ALL LC TO WC",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORCDLR2 CHECK ONE LC TO WC",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORCHECK DELMONO",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORCHECK GETMONO",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORCHECK GETMONOL",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORCHECK GETXTRA",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORCHECK ISMONO",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORCNOTE GET TOTAL",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORDDPAPI ADMTIME",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORDDPAPI CLOZMSG",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORDEA CSVALUE",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORDEA HASHINFO",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORDEA ORDHINFO",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORDEA PINLKCHK",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORDEA PINLKSET",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORDEA PNDHLD",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORDEA SIGINFO",
     "desc": "returns the provider/patient info that must be displayed when signing a controlled substance order(s)",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORECS01 CHKESSO",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORECS01 ECRPT",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORECS01 GETDIV",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORECS01 SAVPATH",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORECS01 VSITID",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX ACTIVE",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX PAT",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX1 AUTHMREL",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX1 CHGEVT",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX1 CMEVTS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX1 COMP",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX1 CPACT",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX1 CURSPE",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX1 DEFLTS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX1 DELDFLT",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX1 DELPTEVT",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX1 DFLTDLG",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX1 DFLTEVT",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX1 DIV",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX1 DIV1",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX1 DLGIEN",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX1 DONE",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX1 EMPTY",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX1 EVT",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX1 EXISTS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX1 GETDLG",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX1 GETSTS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX1 GTEVT",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX1 GTEVT1",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX1 HAVEPRT",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX1 ISDCOD",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX1 ISHDORD",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX1 ISPASS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX1 ISPASS1",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX1 LOC",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX1 LOC1",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX1 MATCH",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX1 MULTS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX1 NAME",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX1 ODPTEVID",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX1 PRMPTID",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX1 PROMPT IDS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX1 PUTEVNT",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX1 SETDFLT",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX1 TYPEXT",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "OREVNTX1 WRLSTED",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORIMO IMOLOC",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORIMO IMOOD",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORIMO ISCLOC",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORIMO ISIVQO",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORK TRIGGER",
     "desc": "This function returns a list of order check messages.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORPRF CLEAR",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORPRF GETFLG",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORPRF HASFLG",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQPT CLINICS",
     "desc": "Function returns a list of clinics.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQPT KILL RPL",
     "desc": "This RPC is passed a ^TMP file root and $J(job number) and kills the ^TMP(“ORRPL”,$J globaldata based on the passed file root w/job number.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQPT MAKE RPL",
     "desc": "Passes Team List IEN, creates a TMP file entry of patients based thereon, and receives a $J job number in return.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQPT PATIENT TEAM PROVIDERS",
     "desc": "Function returns a list of providers linked to a patient via teams.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQPT PROVIDER PATIENTS",
     "desc": "Function returns an array of patients linked to a provider/user.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQPT PROVIDERS",
     "desc": "Function returns an array of providers.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQPT READ RPL",
     "desc": "Passes global reference and other parameters, and receives a list of patients (up to 44 maximum) with IENs, for use in scrolling a Long List Box (LLB) componenet.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQPT SPECIALTIES",
     "desc": "Function returns an array of treating specialties.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQPT SPECIALTY PATIENTS",
     "desc": "Function returns an array of patients linked to a treating specialty.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQPT TEAM PATIENTS",
     "desc": "Function returns an array of patients on a team.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQPT TEAMS",
     "desc": "Function returns a list of teams.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQPT WARD PATIENTS",
     "desc": "Function returns a list of patients on a ward.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQPT WARDS",
     "desc": "Function returns a list of wards.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN ADMIN COMPLETE",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN ATTACH MED RESULTS",
     "desc": "Allows a med result to be attached to a procedure request.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN DEFAULT REQUEST REASON",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN DISCONTINUE",
     "desc": "Discontinue a consult or deny a consult request.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN FIND CONSULT",
     "desc": "Given a Consult IEN in file 123, return a formatted list item for thatsingle consult only, in the same format as returned by ORQQCN LIST.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN FORWARD",
     "desc": "Forwards a consult to a subservice of the forwarding service, as definedin file 123.5",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN GET CONSULT",
     "desc": "Given a Consult ID from file 123, return the zero node to the client forloading into a consult record in RESULTS[0].  If the consult has anyassociated TIU records (completion, addenda) these will be returned inRESULTS[i..j].",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN GET ORDER NUMBER",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN GET PROC IEN",
     "desc": "Given orderable item IEN, return pointer to file 123.3",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN GET PROC SVCS",
     "desc": "Given an orderable item from the S.PROC XREF in 101.43, return theConsults service from 123.5 that can perform the procedure.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN GET SERVICE IEN",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN ISPROSVC",
     "desc": "RPC will return 1 or 0 if the supplied file entry from 123.5 is marked as part of the Consults-Prosthetics interface.  This RPC is used to disable the Earliest Appropriate Date field and value when ordering Prosthetics requests via CPRS GUI.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN LOAD FOR EDIT",
     "desc": "Given a consult IEN, returns the current values of that record’s fields.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN PROVDX",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN RECEIVE",
     "desc": "Test version of RECEIVE CONSULT for use with GUI.  (REV - 8/22/97)",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN RESUBMIT",
     "desc": "Allows resubmission of a cancelled consult or procedure request afterediting.  This is a backdoor resubmission, and CPRS will be notified viathe HL7 proocess.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN SET ACT MENUS",
     "desc": "Based on the IEN of the consult passed in, returns a string representingvarious facets of the user’s access level for that consult and service.This allows dynamic enabling/disabling of GUI menus based on the user’sability to act on that particular consult.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN SIGFIND",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN SVC W/SYNONYMS",
     "desc": "This is a modified version of ORQQCN GET SERVICE TREE that also includessynonyms for the services returned. It also allows passing of an optionalConsult IEN, for screening allowable services to forward the consult to,especially in the case of interfacility consults.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN2 GET CONTEXT",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN2 SCHEDULE CONSULT",
     "desc": "Changes status of consult to “Scheduled”, optionally adding a comment andsending alerts.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPL AUDIT HIST",
     "desc": "RETURN PROBLEM AUDIT HISTORY",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPL CHECK DUP",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPL INACTIVATE",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPL INIT PT",
     "desc": "returns death indicator, sc and exposures",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPL PROBLEM LEX SEARCH",
     "desc": "Get a list from clinical lexicon for display in list or combo box",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPL PROBLEM NTRT BULLETIN",
     "desc": "This RPC generates a bulletin to the OR CAC Mail Group, indicating that an unresolved term needs to be requested using the New Term Rapid Turnaround website at http://hdrmul7.aac.va.gov:7151/ntrt/.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPL SRVC SRCH",
     "desc": "gET LIST OF AVAILABLE SERVICES",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPL USER PROB CATS",
     "desc": "rETURNS ARRAY OF CATEGORIES FOR USER TO SELECT FROM",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPL VERIFY",
     "desc": "VERIFY A TRANSCRIBED PROBLEM",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPL4 LEX",
     "desc": "This RPC supports the Clinical Lexicon Search for Problem List. It will return an indefinite list of terms that match the user’s search string.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPX GET NOT PURPOSE",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPX SET FOLDERS",
     "desc": "Sets the value of the ORQQPX REMINDER FOLDERS parameter for thecurrent user.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPXRM CHECK REM VERSION",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPXRM DIALOG ACTIVE",
     "desc": "For a list of reminders [#811.9] returns same list with status to indicateif an active dialog exists for the reminder.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPXRM DIALOG PROMPTS",
     "desc": "Additional prompts for a given dialog element",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPXRM EDUCATION TOPIC",
     "desc": "Detailed description of education topic",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPXRM GEC DIALOG",
     "desc": "This RPC will evaluate the Reminder Dialogs as the Finish button is clickfor the GEC Project. THis RPC will return an error messages if the fourGEC Reminder Dialogs are done out of order.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPXRM GEC FINISHED?",
     "desc": "This RPC pass a boolean value to PXRMGECU",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPXRM GEC STATUS PROMPT",
     "desc": "This remote procedure will return the text value to display in CPRS of the status of the current GEC Referral.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPXRM MHDLL",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPXRM MHV",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPXRM REMINDER DIALOG",
     "desc": "Dialog for a given reminder",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPXRM REMINDER INQUIRY",
     "desc": "Detailed description of reminder",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQPXRM REMINDER WEB",
     "desc": "Web addresses for selected reminder",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQVI NOTEVIT",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQVI VITALS FOR DATE RANGE",
     "desc": "Function returns a patient’s vital measurements between start date and stop date.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQVI1 GRID",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQVI2 VITALS HELP",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQVI2 VITALS RATE CHECK",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQVI2 VITALS VAL &amp; STORE",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQVI2 VITALS VALIDATE",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQVI2 VITALS VALIDATE TYPE",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQXQA PATIENT",
     "desc": "Function returns a list of notifications for a patient for the current user.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQXQA USER",
     "desc": "Function returns notifications for current user.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORRHCQ QRYITR",
     "desc": "Executes the query for a patient.  An iterator is passed in, in the format:   ListSource Subscript ^ DFN ^ Item# The value returned includes the records found and the next iterator:   PtSearched ^ RecordCount ^ ListSource Subscript ^ NextDFN ^ Next Item#",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWCH LDFONT",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWCH LOADALL",
     "desc": "This RPC returns the sizing related CPRS GUI chart parameters for theuser.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWCH LOADSIZ",
     "desc": "This RPC loads the size (bounds) for a particular CPRS GUI control.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWCH SAVFONT",
     "desc": "Saves the user’s preferred font.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWCIRN AUTORDV",
     "desc": "Get parameter value for ORWRP CIRN AUTOMATIC.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWCIRN CHECKLINK",
     "desc": "Check to see if HL7 TCP link is active.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWCIRN HDRON",
     "desc": "Get parameter value for ORWRP HDR ON",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWCV DTLVST",
     "desc": "This API returns the text of a progress note or discharge summary relatedto a visit/appointment.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWCV POLL",
     "desc": "This RPC is a process to poll the cover sheet tasks for completion anddisplay the information in the appropriate CPRS GUI cover sheet location.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWCV START",
     "desc": "Checks the value of the ORWOR COVER RETRIEVAL parameter and queuesprocesses to build CPRS GUI cover sheet lists as specified in theparameter.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWCV STOP",
     "desc": "RPC to stop retrieval of cover sheet information for CPRS GUI.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWCV VST",
     "desc": "This RPC returns a list of appointments and admissions for a patient basedon parameters that define the beginning and ending range for CPRS GUI.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWD KEY",
     "desc": "RPC which receives a key name and returns a 1 if the user holds the key,otherwise a 0 is returned.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWD SIGN",
     "desc": "Changes signature status on a list of orders and optionally releases theorders to their respective services.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWD1 SVONLY",
     "desc": "Prints service copies only (used when user says “Don’t Print” for theother copies).",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDAL32 ALLERGY MATCH",
     "desc": "Given a text string, return a list of possible matches from severaldifferent sources.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDAL32 CLINUSER",
     "desc": "Determine if user can perform cover sheet allergy actions.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDAL32 LOAD FOR EDIT",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDAL32 SEND BULLETIN",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDAL32 SITE PARAMS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDAL32 SYMPTOMS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDBA1 GETORDX",
     "desc": "ARRAY OF DIAGNOSES ASSOCIATED WITH AN ORDER",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDBA1 ORPKGTYP",
     "desc": "Array of Order Package Types",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDBA1 RCVORCI",
     "desc": "Receive Order Entry Billing Aware data from CPRS.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDBA1 SCLST",
     "desc": "Array of Order ID’s and SC.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDBA2 DELPDL",
     "desc": "Delete a selected diagnosis code from a Clinician’s Personal DX List. The personal dx list is stored in CPRS Diagnosis Provider file, file # 5000017.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDBA2 GETDUDC",
     "desc": "This returns a list of unique ICD9 diagnoses codes and their descriptions on orders placed by a clinician for a patient for today. This will be used to help in filling out the encounter form.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDBA4 GETBAUSR",
     "desc": "Gets the value of the Enable Billing Awareness By User parameter. The value returned will be 1 for Yes, Billing Awareness Enabled, and 0 for No, Billing Awareness Disabled.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDBA4 GETTFCI",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDBA7 GETIEN9",
     "desc": "Receive external ICD9 number and return IEN",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDBA7 ISWITCH",
     "desc": "CIDC RPCRETURNS 1 IF PATIENT HAS BILLABLE INSURANCERETURNS 0 IF PATIENT DOES NOT HAVE BILLABLE INSURANCE",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDCN32 DEF",
     "desc": "Load dialog data (lists &amp; defaults) for a consult order. (32-BIT)",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDCN32 ORDRMSG",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDCSLT DEF",
     "desc": "Load dialog data (lists &amp; defaults) for a consult order. (16-BIT)",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDCSLT LOOK200",
     "desc": "Validates Attn: field of a consult order.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDFH ATTR",
     "desc": "For a diet order, this RPC returns:  Orderable Item^Text^Type^Precedence^AskExpire",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDFH CURRENT MEALS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDFH OPDIETS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDFH TXT",
     "desc": "RPC to return the text of the current and any future diets for a patient.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDGX LOAD",
     "desc": "Loads a list of activities for an activity order.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDGX VMDEF",
     "desc": "Loads dialog data (lists &amp; defaults) for a vitals order.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDLR DEF",
     "desc": "Loads dialog data (lists &amp; defaults) for a lab order.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDLR LOAD",
     "desc": "Loads sample, specimen, and urgency information for a given lab test.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDLR OIPARAM",
     "desc": "No longer used.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDLR STOP",
     "desc": "Calculates a stop date (for lab orders with schedules).",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDLR32 DEF",
     "desc": "Get lab order dialog definition.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDLR32 IC VALID",
     "desc": "Determines whether the suplied time is a valid lab immediate collect time.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDLR32 LAB COLL TIME",
     "desc": "Is the given time a routine lab collection time for the given location?",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDLR33 LASTTIME",
     "desc": "When entering quick orders from an order menu, the ^TMP(“ORECALL”,$J)array contains the last responses entered.  This RPC allows retrieval ofthe previous order’s collection time from that array.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDLR33 LC TO WC",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDOR LKSCRN",
     "desc": "Does a lookup similar to GENERIC^ORWU.  Also allows passing of a referenceto a screen in the Order Dialog file to screen to lookup.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDOR VALNUM",
     "desc": "Validates a numeric entry.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS1 CHK94",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS1 DFLTSPLY",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS1 DOSEALT",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS1 DOWSCH",
     "desc": "This RPC returns a list of schedule that have a frequency defined and the frequency is less then or equal to 1440 minutes",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS1 FAILDEA",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS1 FORMALT",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS1 HASOIPI",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS1 HASROUTE",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS1 IVDEA",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS1 LOCPICK",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS1 ODSLCT",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS1 QOMEDALT",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS1 SCHALL",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS2 ADMIN",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS2 CHKGRP",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS2 CHKPI",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS2 DAY2QTY",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS2 MAXREF",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS2 OISLCT",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS2 QOGRP",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS2 QTY2DAY",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS2 REQST",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS2 SCHREQ",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS32 ALLIVRTE",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS32 AUTH",
     "desc": "Checks restrictions for entering inpatient meds.  If no restrictions, a 0is returned.  If there is a restriction, it is returned in the format:     1^restriction text",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS32 AUTHNVA",
     "desc": "Checks restrictions for entering non-VA meds.  If no restrictions, a 0 isreturned.  If there is a restriction, it is returned in the format:1^restriction text",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS32 VALQTY",
     "desc": "Validate a medication quantity and return a 1 if it is valid, otherwisereturn 0.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS32 VALSCH",
     "desc": "Validate a schedule and return a 1 if it is valid, otherwise return 0.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS33 COMPLOC",
     "desc": "This RPC will return a 0 if the patient location is the same location as the original order. It will return a 1 if the location is different.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS33 IVDOSFRM",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS4 CPINFO",
     "desc": "Save outpatient med order co-pay information.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS4 CPLST",
     "desc": "Get co-pay ralated questions",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS4 IPOD4OP",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS4 ISUDIV",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS4 UPDTDG",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS5 ISVTP",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS5 LESAPI",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDPS5 LESGRP",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDRA DEF",
     "desc": "Loads dialog data (lists &amp; defaults) for a radiology order.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDRA32 APPROVAL",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDRA32 DEF",
     "desc": "Loads dialog data (lists &amp; defaults) for a radiology order.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDRA32 IMTYPSEL",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDRA32 ISOLATN",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDRA32 LOCTYPE",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDRA32 PROCMSG",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDRA32 RADSRC",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDRA32 RAORDITM",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDX CHANGE",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDX DGNM",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDX LOADRSP",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDX LOCK",
     "desc": "RPC to attempt to lock patient for ordering (returns 1 if successful or 0if unsuccessful).",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDX LOCK ORDER",
     "desc": "RPC to attempt to lock a specific order.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDX SEND",
     "desc": "RPC to sign a list of orders with input as follows:        DFN=Patient        ORNP=Provider        ORL=Location        ES=Encrypted ES code         ORWREC(n)=ORIFN;Action^Signature Sts^Release Sts^Nature of Order",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDX SENDED",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDX SENDP",
     "desc": "Same as ORWDX SEND, but allows print devices as parameter.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDX UNLKOTH",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDX UNLOCK",
     "desc": "Unlocks the patient for ordering purposes.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDX UNLOCK ORDER",
     "desc": "RPC to unlock a specific order.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDX1 DCORIG",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDX1 DCREN",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDX1 ORDMATCH",
     "desc": "This RPC will accept a list of orders and each order status, if one of the order does not have a status it will return a false value.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDX1 PATWARD",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDX1 STCHANGE",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDX1 UNDCORIG",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDX2 DCREASON",
     "desc": "RPC to return a list of valid discontinuation reasons.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXA ALERT",
     "desc": "Set order to send an alert when the order is resulted.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXA COMPLETE",
     "desc": "Complete an order.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXA DC",
     "desc": "RPC to discontinue, cancel, or delete an existing order.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXA FLAG",
     "desc": "Flag an existing order.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXA HOLD",
     "desc": "RPC to place an existing order on hold.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXA ISACTOI",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXA OFCPLX",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXA UNFLAG",
     "desc": "Unflag an existing order.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXA UNHOLD",
     "desc": "RPC to remove a particular order from hold status.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXA VERIFY",
     "desc": "Verify an order via CPRS GUI.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXA WCPUT",
     "desc": "Set ward comments for an order.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXC DELORD",
     "desc": "Delete order.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXM AUTOACK",
     "desc": "Place a quick order in CPRS GUI without the verify step.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXM1 BLDQRSP",
     "desc": "Build responses for an order Input:      1   2    3    4   5   6    7    8        11-20FLDS=DFN^LOC^ORNP^INPT^SEX^AGE^EVENT^SC%^^^Key Variables…ORIT=+ORIT: ptr to 101.41, $E(ORIT)=C: copy $E(ORIT)=X: change Output:LST=QuickLevel^ResponseID(ORIT;$H)^Dialog^Type^FormID^DGrpLST(n)=verify text or rejection text",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXM1 SVRPC",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXM2 CLRRCL",
     "desc": "Clear ORECALL.  Used by CPRS GUI to clean up ^TMP(“ORECALL”,$J) and^TMP(“ORWDXMQ”,$J).",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXM3 ISUDQO",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXQ PUTQLST",
     "desc": "Save quick order list.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXQ PUTQNAM",
     "desc": "Save display name for quick order dialog.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXR CANRN",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXR GETPKG",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXR GTORITM",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXR ISCPLX",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXR ISNOW",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXR ORCPLX",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXR RENEW",
     "desc": "Renew an existing order.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXR01 CANCHG",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXR01 ISSPLY",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXR01 OXDATA",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXR01 SAVCHG",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXVB COMPORD",
     "desc": "Get sequence order of Blood Components for selection.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXVB NURSADMN",
     "desc": "This procedure checks the parameter OR VBECS SUPPRESS NURS ADMIN to seeif the Nursing Administration Order prompt/pop-up should be supressedafter a VBECS Blood Bank order has been created.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXVB STATALOW",
     "desc": "Check to see if user is allowed to order STAT orders through VBECS.Checks users with parameter: OR VBECS STAT USER",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXVB SUBCHK",
     "desc": "Check to see if selected test is a Blood Component or a Diagnostic Test.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXVB VBTNS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXVB3 COLLTIM",
     "desc": "This RPC checks the value of the parameter OR VBECS REMOVE COLL TIMEto determine if a default collection time should be presented on theVBECS order dialog.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXVB3 DIAGORD",
     "desc": "Get sequence order of Diagnostic Tests for selection.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWDXVB3 SWPANEL",
     "desc": "This RPC checks the value of the parameter OR VBECS DIAGNOSTIC PANEL 1STto determine the location of the Diagnostic and Component panels on theVBECS order dialog.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWGEPT CLINRNG",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWGN AUTHUSR",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWGN GNLOC",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWGN MAXFRQ",
     "desc": "This RPC checks if the frequency of an ICD-10 search term is than the maximum allowed ICD-10 return values.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWGRPC ALLITEMS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWGRPC ALLVIEWS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWGRPC CLASS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWGRPC DATEITEM",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWGRPC DELVIEWS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWGRPC FASTDATA",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWGRPC FASTITEM",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWGRPC FASTLABS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWGRPC FASTTASK",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWGRPC GETDATES",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWGRPC GETPREF",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWGRPC GETSIZE",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWGRPC GETVIEWS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWGRPC ITEMDATA",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWGRPC ITEMS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWGRPC LOOKUP",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWGRPC PUBLIC",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWGRPC RPTPARAM",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWGRPC SETPREF",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWGRPC SETSIZE",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWGRPC SETVIEWS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWGRPC TAX",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWGRPC TESTING",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWGRPC TESTSPEC",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWGRPC TYPES",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWLEX GETFREQ",
     "desc": "This call wraps the Lexicon API $$FREQ^LEXU to satisfy the requirements of the ICD-10-CM diagnosis search.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWLEX GETI10DX",
     "desc": "This call wraps the Lexicon API $$DIAGSRCH^LEX10CS to satisfy the requirements of the ICD-10-CM diagnosis search.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWLR CUMULATIVE SECTION",
     "desc": "This rpc retrieves the part of the lab cumulative report selected by the user on the Labs tab.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWLRR ALLTESTS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWLRR ATESTS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWLRR ATG",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWLRR ATOMICS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWLRR CHART",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWLRR CHEMTEST",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWLRR GRID",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWLRR INTERIM",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWLRR INTERIMG",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWLRR INTERIMS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWLRR MICRO",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWLRR NEWOLD",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWLRR PARAM",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWLRR SPEC",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWLRR TG",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWLRR USERS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWLRR UTGA",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWLRR UTGD",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWLRR UTGR",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWMC PATIENT PROCEDURES",
     "desc": "This remote procedure call returns a list of patient procedures for a specific patient.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWMC PATIENT PROCEDURES1",
     "desc": "This remote procedure call returns a list of patient procedures for a specific patient.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWMHV MHV",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWNSS CHKSCH",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWNSS NSSMSG",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWNSS QOSCH",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWNSS VALSCH",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWOR ACTION TEXT",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWOR PKISITE",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWOR PKIUSE",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWOR VWSET",
     "desc": "Sets the default view on the orders tab for the user.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWOR1 SETDTEXT",
     "desc": "Sets/updates the external text of an order.The updated text is also returned.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWORB AUTOUNFLAG ORDERS",
     "desc": "Auto unflag orders/delete alert.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWORB FASTUSER",
     "desc": "Function returns notifications for current user.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWORB GET TIU ALERT INFO",
     "desc": "Given a TIU XQAID, return the patient and document type for the item beingalerted.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWORB GETDATA",
     "desc": "Given an XQAID, return XQADATA for an alert.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWORB KILL EXPIR MED ALERT",
     "desc": "Evaluate expiring med orders.  If none remain, kill current alert forcurrent user.  Kill for other users if alert so defined.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWORB KILL EXPIR OI ALERT",
     "desc": "Evaluate expiring flagged orderable item orders. If none remain, killcurrent alert for current user.  Kill for other users if alert so defined.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWORB KILL UNSIG ORDERS ALERT",
     "desc": "Check patient’s unsigned orders, and kill unsigned orders alert for thisuser if no unsigned orders remain for his/her signature.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWORB KILL UNVER MEDS ALERT",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWORB KILL UNVER ORDERS ALERT",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWORB SETSORT",
     "desc": "Sets the GUI alert sort method for the user.  This is set when a user clicks on the GUI alert columns to change the display sorting.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWORB UNSIG ORDERS FOLLOWUP",
     "desc": "After viewing unsigned orders for a patient via an alert, evaluateswhether the alert should be deleted for the current user. The following two exception conditions exist when determining how alertdeletion will occur.  In all other cases, alert deletion will occur whenthe patient has no unsigned orders. 1)      If the recipient of this alert does NOT have the ORES key, thealert will be deleted for that recipient after he reviews the unsignedorders.  2)      If the recipient has the ORES key and is NOT linked to the patientas attending, inpatient primary provider or via OE/RR teams, his alertwill be deleted when his unsigned orders are signed.  (If unsigned orderswritten by other providers for the patient remain, alerts for these other providers will not be deleted.)  For example, a consulting surgeon (withORES) places three unsigned orders for a patient.  He then receives an”Order requires electronic signature” alert for the patient.  He uses the View Alerts follow-up action and is presented with ten unsigned orders forthe patient.  Only three of the ten orders are his.  The surgeon signs histhree unsigned orders.  If the surgeon is not linked to the patient asattending, inpatient primary providers or via OE/RR teams, the alert will be deleted (for him only.)   In most cases alert deletion will occur when the patient has no unsignedorders.  For example, if a recipient has the ORES key and is linked to thepatient as attending, inpatient primary provider or via OE/RR teams, allunsigned orders for the patient must be signed before his alert isdeleted.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWORDG MAPSEQ",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWORR AGET",
     "desc": "Get an abbreviated order list for a patient in the format:     ^TMP(“ORR”,$J,ORLIST,n)=IFN^DGrp^ActTm",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWORR RGET",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE ACTIVE CODE",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE ACTPROB",
     "desc": "Build list of active problems for patient.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE CXNOSHOW",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE GET DX TEXT",
     "desc": "Resolves the preferred expanded form of the Diagnosis text for the encounter pane on the notes tab.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE GETSVC",
     "desc": "Calculates the correct service category.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE I10IMPDT",
     "desc": "This RPC returns the ICD-10 implementation date in FM Date/Time format.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE MH TEST AUTHORIZED",
     "desc": "Indicates if a given mental health test can be given by the given user.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPCE1 NONCOUNT",
     "desc": "Is a given HOSPITAL LOCATION (file 44) a non-count clinic?  (DBIA #964)",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPFSS IS PFSS ACTIVE?",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPS MEDHIST",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPS1 REFILL",
     "desc": "RPC to submit a request for a refill.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPT DISCHARGE",
     "desc": "Given a patient and an admission date, return the discharge date/time.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPT FULLSSN",
     "desc": "Given an SSN in the format 999999999(P), return a list of matchingpatients.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPT FULLSSN RPL",
     "desc": "Given an SSN in the format 999999999(P), return a list of matching patients based on Restricted Patient List.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPT SAVDFLT",
     "desc": "Saves user’s preference for default list source.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPT SELECT",
     "desc": "RPC to return key information on a patient as follows: 1    2   3   4    5      6    7    8       9       10      11   12 13NAME^SEX^DOB^SSN^LOCIEN^LOCNM^RMBD^CWAD^SENSITIVE^ADMITTED^CONV^SC^SC%^ 14  15  16  17ICN^AGE^TS^TSSVC",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPT SHARE",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPT16 ADMITLST",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPT16 APPTLST",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPT16 DEMOG",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPT16 GETVSIT",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPT16 ID INFO",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPT16 LOOKUP",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWPT16 PSCNVT",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWRA DEFAULT EXAM SETTINGS",
     "desc": "This RPC returns the default settings for the display of imaging exams onthe reports tab.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWRA IMAGING EXAMS",
     "desc": "This remote procedure call returns a list on imaging exams for aspecific patient.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWRA IMAGING EXAMS1",
     "desc": "This remote procedure call returns a list on imaging exams for aspecific patient.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWRP COLUMN HEADERS",
     "desc": "Get list of Column headers for a ListView type report from file 101.24.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWRP2 COMPABV",
     "desc": "This RPC returns an array of the ADHOC Health Summary components by abbreviation.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWRP2 COMPDISP",
     "desc": "This RPC returns an array of the ADHOC Health Summary components by display name.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWRP2 GETLKUP",
     "desc": "This gets the last Adhoc Health Summary lookup used by a user in CPRS.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWRP2 HS COMP FILES",
     "desc": "This RPC gets a list of files to select from for the ADHOC Health Summary.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWRP2 HS COMPONENT SUBS",
     "desc": "This RPC returns an array of ADHOC Health Summary subcomponents.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWRP2 HS COMPONENTS",
     "desc": "This RPC returns an array of the ADHOC Health Summary components.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWRP2 HS FILE LOOKUP",
     "desc": "This RPC gets the list of file entries for the file defined for a specificHealth Summary component on the ADHOC Health Summary.  Current choicesinclude files 60, 9999999.64, 811.9, 8925.1, 81, and possibly others(handled generically).  The file entries are used to populate a combo boxon the form.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWRP2 HS SUBITEMS",
     "desc": "This RPC expands a Laboratory Test panel to all it’s sub-components forselection in the ADHOC Health Summary.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWRP2 SAVLKUP",
     "desc": "This saves the last Adhoc Health Summary lookup used by a user in CPRS.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWRP3 EXPAND COLUMNS",
     "desc": "This RPC loads and expands nested reports defined in the OE/RR Reportsfile (#101.24) for use on the Reports Tab in CPRS.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWRP4 HDR MODIFY",
     "desc": "This RPC looks at data returned from the HDR and makes any modificationsnecessary to make the data compatible with CPRS Reports.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWSR GET SURG CONTEXT",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWSR IS NON-OR PROCEDURE",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWSR ONECASE",
     "desc": "Given a TIU document IEN, return the surgical case record and all otherdocuments related to the case, for display in the GUI treeview.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWSR SHOW OPTOP WHEN SIGNING",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWSR SHOW SURG TAB",
     "desc": "Check for presence of SR",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTIU CANLINK",
     "desc": "Given a title, call CANLINK^TIULP to determine whether this title can use linked as an Interdisciplinary child note. dbia #2322",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTIU CHKTXT",
     "desc": "Check for existence of text in TIU(8925,TIUDA, either in “TEXT” or “TEMP” nodes, before allowing signature.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTIU GET DCSUMM CONTEXT",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTIU GET TIU CONTEXT",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPD ACTDF",
     "desc": "Make default time/occ setting take action on each report",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPD DELDFLT",
     "desc": "Delete user level’s specific health summary component setting( date range and max occurences)",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPD GETDFLT",
     "desc": "get default setting for all reports(time/occ limits)",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPD GETIMG",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPD GETOCM",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPD GETSETS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPD PUTOCM",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPD RSDFLT",
     "desc": "get system or package level default setting for all repors.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPD SUDF",
     "desc": "Set user level default time/occ limits for all reports",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPD SUINDV",
     "desc": "set user level individual report’s time/occ setting",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPD1 GETCSDEF",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPD1 GETCSRNG",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPD1 GETEAFL",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPD1 GETEDATS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPD1 GETEFDAT",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPD1 PUTCSRNG",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPD1 PUTEDATS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPN GETCLASS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPN GETTC",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPO CSARNGD",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPO CSLABD",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPO GETIMGD",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPO GETTABS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP CHKSURR",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP CLDAYS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP CLEARNOT",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP CLRANGE",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP CSARNG",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP CSLAB",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP GETCOMBO",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP GETCOS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP GETDCOS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP GETIMG",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP GETNOT",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP GETNOTO",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP GETOC",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP GETOTHER",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP GETREM",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP GETSUB",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP GETSURR",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP GETTD",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP GETTU",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP LSDEF",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP PLTEAMS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP SETCOMBO",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP SETDCOS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP SETIMG",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP SETOTHER",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP SETREM",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP SETSUB",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP SORTDEF",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPP TEAMS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPR NOTDESC",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPR OCDESC",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPT ATEAMS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTPT GETTEAM",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWU PARAM",
     "desc": "Simple call to return a parameter value.  The call assumes the currentuser, ‘defaultable’ entities, and one instance.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWU PARAMS",
     "desc": "Simple call to return a list of parameter values such as:         INST1^VALUE1        INST2^VALUE2        …        INSTN^VALUEN The call assumes the current user, ‘defaultable’ entities and multiple instances.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWU VALDT",
     "desc": "Validates date/time entry and returns value of Y from %DT call.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWU VALIDSIG",
     "desc": "Validates a broker encrypted electronic signature.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWU1 NAMECVT",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWU16 DEVICE",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWU16 HOSPLOC",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWU16 NEWPERS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWU16 VALDT",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWU16 VALIDSIG",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWUL FV4DG",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWUL FVIDX",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWUL FVSUB",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWUL QV4DG",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWUL QVIDX",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWUL QVSUB",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWUXT LST",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWUXT REF",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWUXT VAL",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "PXRM REMINDER CATEGORY",
     "desc": "List reminders and categories in display order for a reminder category.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "PXRM REMINDER DIALOG (TIU)",
     "desc": "Dialog for a given dialog ien.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU AUTHORIZATION",
     "desc": "This RPC allows the calling application to evaluate privilege to performany ASU-mediated action on a TIU document.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU CAN CHANGE COSIGNER?",
     "desc": "BOOLEAN RPC to evaluate user’s privilege to modify the expected cosigner, given the current status of the document, and the user’s role with respect to it.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU FIELD CHECK",
     "desc": "Very similar to IMPORT^TIUSRVF, except does not save template fields.Resolves self referencing loops, and takes into account fields withthe same name already saved.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU FIELD DOLMTEXT",
     "desc": "Reads through an array of text and converts all entries of templatefields to their assocaited List Manager text values.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU FIELD EXPORT",
     "desc": "Exports Template Fields in XML format",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU FIELD IMPORT",
     "desc": "Imports Template Fields from XML format",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU FIELD LOCK",
     "desc": "Locks a template field record for editing",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU FIELD UNLOCK",
     "desc": "Unlock Template Field",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU GET ALERT INFO",
     "desc": "Given a TIU XQAID, return the patient and document type for the item beingalerted.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU GET DEFAULT PROVIDER",
     "desc": "This RPC returns the default provider as specified by the TIU Site ParameterDEFAULT PRIMARY PROVIDER, which has the following allowable values:0      NONE, DON’T PROMTIn which case the call will return 0^1      DEFAULT, BY LOCATIONIn this case, the call will return the default provider for a given HospitalLocation, as specified in the set-up for the Clinic in MAS. If a defaultprovider is specified for the location in question, that person will bereturned. If the Clinic set-up specifies use of the Primary Provider (if defined) for the patient, then that person will be returned. The returnformat will be DUZ^LASTNAME,FIRSTNAME.2      AUTHOR (IF PROVIDER)In this case, the call will return the current user (if they are a known Provider). If their not a known Provider, then the call will return 0^.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU GET DOCUMENT PARAMETERS",
     "desc": "This Remote Procedure returns the parameters by which a given documentor document type is to be processed.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU GET DOCUMENT STATUS",
     "desc": "This RPC is used to retrieve the Status (8925.6 IEN) of a TIU DOCUMENT.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU GET DOCUMENT TITLE",
     "desc": "This remote procedure returns the pointer to the TIU DOCUMENT DEFINITIONFILE that corresponds to the TITLE of the document identified in the TIUDAparameter.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU GET DOCUMENTS FOR REQUEST",
     "desc": "This Remote Procedure returns the list of documents associated with agiven Request (e.g., Consult Request, or Surgical Case).",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU GET DS TITLES",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU GET PN TITLES",
     "desc": "This API returns a list of Progress Notes Titles, including a SHORT LISTof preferred titles as defined by the user, and a LONG LIST of all titlesdefined at the site.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU GET PRF ACTIONS",
     "desc": "This RPC gets the Patient Record Flag History Assignments/Actions for a Patient/Title Combination.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU GET RECORD TEXT",
     "desc": "This RPC will get the textual portion of a TIU Document Record.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU GET REQUEST",
     "desc": "This Remote Procedure returns the variable pointer to the REQUESTINGPACKAGE REFERENCE (File #8925, Field #1405). This would be the record inthe Requesting Package (e.g., Consult/Request Tracking or Surgery) forwhich the resulting document has been entered in TIU.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU GET SITE PARAMETERS",
     "desc": "This RPC returns the TIU Parameters for the Division the user is logged in to.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU ID ATTACH ENTRY",
     "desc": "This RPC will attach a a document as an Interdisciplinary (ID) entry to anID Parent document.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU ID CAN ATTACH",
     "desc": "This BOOLEAN RPC evaluates the question of whether a particular documentmay be attached as an entry to an Interdisciplinary Note (i.e., can thisdocument be an ID Child?).",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU ID CAN RECEIVE",
     "desc": "This BOOLEAN RPC evaluates the question of whether a particular documentmay receive an entry as an Interdisciplinary Parent Note (i.e., can thisdocument be an ID Parent?).",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU ID DETACH ENTRY",
     "desc": "This call will remove an ID Entry from an Interdisciplinary Note.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU IDENTIFY CLINPROC CLASS",
     "desc": "This RPC gets the CLINICAL PROCEDURES TIU Document Definitionfile (#8925.1) IEN.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU IDENTIFY CONSULTS CLASS",
     "desc": "This RPC returns the record number of the class CONSULTS in the TIUDOCUMENT DEFINITION file (#8925.1).",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU IDENTIFY SURGERY CLASS",
     "desc": "This RPC returns the record number of the class identified by the CLNAMEparameter in the TIU DOCUMENT DEFINITION file (#8925.1).",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU IS THIS A CLINPROC?",
     "desc": "This RPC evaluates whether or not a Title is under theCLINICAL PROCEDURES Class.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU IS THIS A CONSULT?",
     "desc": "BOOLEAN RPC which evaluates whether the title indicated is that of aconsult.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU IS THIS A SURGERY?",
     "desc": "BOOLEAN RPC which evaluates whether the title indicated is that of aSURGICAL REPORT or PROCEDURE REPORT (NON-O.R.).",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU IS USER A PROVIDER?",
     "desc": "This Boolean RPC returns TRUE if the user was a known provider on the date specified.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU IS USER A USR PROVIDER",
     "desc": "This Boolean RPC returns TRUE if the user was a member of USR CLASS PROVIDER on the date specified.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU ISPRF",
     "desc": "This RPC is to check to see if the passed in TIU DOCUMENT TITLE IEN is a Patient Record Flag TITLE.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU LINK TO FLAG",
     "desc": "This RPC is used to link a Progress Note to a Patient Record Flag",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU LOAD BOILERPLATE TEXT",
     "desc": "This RPC will load the boilerplate text associated with the selectedtitle, and execute the methods for any objects embedded in the boilerplatetext.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU LOAD RECORD FOR EDIT",
     "desc": "This RPC loads the return array with data in a format consistent with thatrequired by the TIU UPDATE RECORD API.  It should be invoked when the userinvokes the Edit action, to load the dialog for editing the document.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU LOCK RECORD",
     "desc": "This RPC will issue an incremental LOCK on the record identified by theTIUDA parameter, returning an integer truth value indicating successor failure in obtaining the LOCK.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU NOTES",
     "desc": "This API gets lists of progress notes for a patient, with optional parameters for STATUS, EARLY DATE/TIME, and LATE DATE/TIME.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU NOTES 16 BIT",
     "desc": "This API gets lists of progress notes for a patient, with optional parameters for STATUS, EARLY DATE/TIME, and LATE DATE/TIME.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU NOTES BY VISIT",
     "desc": "This API gets lists of Progress Notes by visit from TIU.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU ONE VISIT NOTE?",
     "desc": "Boolean RPC to evaulate if note has a corresponding visit.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU REQUIRES COSIGNATURE",
     "desc": "This Boolean RPC simply evaluates whether the current user requirescosignature for TIU DOCUMENTS, and returns a 1 if true, or a 0 if false.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU SET ADMINISTRATIVE CLOSURE",
     "desc": "This remote procedure sets the file attributes necessary to close adocument by administrative action (either manually or by scanning a paperdocument that doesn’t require the signature of an author as a typical TIUDocument would).",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU SET DOCUMENT TEXT",
     "desc": "This RPC buffers the transmittal of text (i.e., the body of TIU Documents)from the Client to the Server. It allows documents of indefinite size tobe filed, without risk of an allocate error on the M Server.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU SIGN RECORD",
     "desc": "This API Supports the application of the user’s electronic signature to aTIU document while evaluating authorization, and validating the user’selectronic signature.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU SUMMARIES",
     "desc": "This API gets lists of Discharge Summaries for a patient, with optional parameters for STATUS, EARLY DATE/TIME, and LATE DATE/TIME.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU SUMMARIES BY VISIT",
     "desc": "This API returns lists of Discharge Summaries by visit.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU TEMPLATE ACCESS LEVEL",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU TEMPLATE CHECK BOILERPLATE",
     "desc": "This RPC will evaluate boilerplate passed in the input array, checking tosee whether any of the embedded objects are inactive, faulty, orambiguous.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU TEMPLATE GETBOIL",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU TEMPLATE GETITEMS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU TEMPLATE GETPROOT",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU TEMPLATE GETROOTS",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU TEMPLATE GETTEXT",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU TEMPLATE ISEDITOR",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU TEMPLATE LOCK",
     "desc": "Locks Template",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU TEMPLATE SET DEFAULTS",
     "desc": "Saves Template Default Settings",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU TEMPLATE SET ITEMS",
     "desc": "This RPC will create or update the items for a Group, Class, or Root.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU TEMPLATE UNLOCK",
     "desc": "Unlocks a template.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU UNLOCK RECORD",
     "desc": "This RPC will decrement the lock on a given TIU Document Record, identifiedby the TIUDA input parameter. The return value will always be 0.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU WHICH SIGNATURE ACTION",
     "desc": "This RPC infers whether the user is trying to sign or cosign the docuementin question, and indicates which ASU ACTION the GUI should pass to the TIUAUTHORIZATION RPC.",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "VAFCTFU CONVERT ICN TO DFN",
     "desc": "Given a patient Integration Control Number (ICN), this will returnthe patient Internal Entry Number (IEN) from the PATIENT file (#2).",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "YS GAF API",
     "desc": "",
     "category": "unknown",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "GMV MANAGER",
     "desc": "Performs many functions for the Manager module. This remote procedure call is documented in Integration Agreement 4360.",
     "category": "user-preferences",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "GMV PARAMETER",
     "desc": "Sets and retrieves parameter values used by the graphical user interface. This remote procedure call is documented in Integration Agreement 4367.",
     "category": "user-preferences",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "GMV USER",
     "desc": "Retrieves data about the user (e.g., parameter settings). This remote procedure call is documented in Integration Agreement 4366.",
     "category": "user-preferences",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "GMV CLOSEST READING",
     "desc": "This remote procedure call returns the observation date/time and reading of the record closest to the date/time specified for the patient and vitaltype.",
     "category": "utility",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "GMV CONVERT DATE",
     "desc": "This remote procedure call converts a user-supplied date/time into VAFileMan’s internal and external date format. This remote procedure call is documented in Integration Agreement 4353.",
     "category": "utility",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "GMV DLL VERSION",
     "desc": "Returns a YES or NO response to indicate if the Dynamic Link Library (DLL)file should be used. This remote procedure call is documented in Integration Agreement 4420.",
     "category": "utility",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "GMV GET CURRENT TIME",
     "desc": "Gets the current date and time from the server. This remote procedure call is documented in Integration Agreement 4355.",
     "category": "utility",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORECS01 ECPRINT",
     "desc": "",
     "category": "utility",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN PRINT SF513",
     "desc": "",
     "category": "utility",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORQQCN SF513 WINDOWS PRINT",
     "desc": "Print consults Standard Form 513 to Windows device from GUI application.",
     "category": "utility",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWCS PRINT REPORT",
     "desc": "This rpc is used to print a consult report on the Consult tabin CPRS.",
     "category": "utility",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWD1 PRINTGUI",
     "desc": "RPC used by CPRS GUI to print orders to a designated print device.",
     "category": "utility",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWD1 RVPRINT",
     "desc": "RPC used by CPRS GUI to print orders to a designated print device afterthe review or sign actions were used.",
     "category": "utility",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWRA PRINT REPORT",
     "desc": "This rpc is used to print an imaging report on the Imaging tabin CPRS.",
     "category": "utility",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWRP GET DEFAULT PRINTER",
     "desc": "Returns default printer.",
     "category": "utility",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWRP PRINT LAB REMOTE",
     "desc": "This rpc is used to print a remote report on the Labs tab in CPRS. RETURN PARAMETER DESCRIPTION: If the print request was successfully queued then the Task manager task number is return. Otherwise, and error code and error description are returned. Error Code Table:       Code            Text      —-            —-        0             ",
     "category": "utility",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWRP PRINT LAB REPORTS",
     "desc": "This rpc is used to print a report on the Labs tabin CPRS.",
     "category": "utility",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWRP PRINT REMOTE REPORT",
     "desc": "This rpc is used to print a remote report on the Report tab in CPRS.",
     "category": "utility",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWRP PRINT REPORT",
     "desc": "This rpc is used to print a report on the Report tabin CPRS.",
     "category": "utility",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWRP PRINT V REPORT",
     "desc": "This rpc is used to print a V type report on the Reports tab in CPRS",
     "category": "utility",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWRP PRINT WINDOWS LAB REMOTE",
     "desc": "Prints remote CPRS GUI information to windows printer.",
     "category": "utility",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWRP PRINT WINDOWS REMOTE",
     "desc": "Prints CPRS GUI information to windows printer.",
     "category": "utility",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWRP PRINT WINDOWS REPORT",
     "desc": "Prints CPRS GUI information to windows printer.",
     "category": "utility",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWRP SAVE DEFAULT PRINTER",
     "desc": "Saves printer as user’s default printer.",
     "category": "utility",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWRP WINPRINT DEFAULT",
     "desc": "Returns whether the Windows printer is set as the default for the user.",
     "category": "utility",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWRP WINPRINT LAB REPORTS",
     "desc": "Prints text from CPRS GUI to a windows printer.",
     "category": "utility",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "ORWTIU WINPRINT NOTE",
     "desc": "Returns a formatted global of a TIU document for output to a Windows printdevice.",
     "category": "utility",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU GET PRINT NAME",
     "desc": "This Remote Procedure receives a pointer to the TIU DOCUMENT DEFINITIONFILE (#8925.1) and returns a string containing the Print Name of thecorresponding Document Definition.",
     "category": "utility",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "TIU PRINT RECORD",
     "desc": "Allows Printing of TIU Documents on demand.",
     "category": "utility",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "XWB CREATE CONTEXT",
     "desc": "Establishes context on the server, which will be checked by the Broker beforeexecuting any other remote procedure.  Since context is nothing more than aclient/server “B”-type option in the OPTION file (#19), standard MenuMansecurity is applied in establishing a context.  Therefore, a context optioncan be granted to user(s) exactly the same way as regular options are doneusing MenuMan.A context can not be established for the following reasons:        The user has no access to that option        The option is temporarily out of orderAn application can switch from one context to another as often as it needs to.Each time a context is created the previous context is overwritten.For more information on creating a context and the overall Broker securitysee Broker on-line help documentation.",
     "category": "utility",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "XWB DEFERRED CLEARALL",
     "desc": "This RPC is used to CLEAR all the data known to this job in the ^XTMPglobal.  Makes use of the list in ^TMP(“XWBHDL”,$J,handle).",
     "category": "utility",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "XWB DIRECT RPC",
     "desc": "This is the Broker RPC that is called to request that a RPC be run on aremote system.  The data is passed by HL7 to the remote system as is thereturn value.  The difference between this and the XWB REMOTE RPC is thisis a blocking call meaning the user’s workstation will not processanything else until the data returns from the remote system.",
     "category": "utility",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "XWB GET BROKER INFO",
     "desc": "Returns info regarding setup and parameters of the Broker.",
     "category": "utility",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "XWB GET VARIABLE VALUE",
     "desc": "This RPC accepts the name of a variable which will be evaluated and itsvalue returned to the server.  For example, this RPC may be called witha parameter like DUZ which will be returned as 123456.",
     "category": "utility",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "XWB IM HERE",
     "desc": "Returns a simple value to the client.  Used to establish continued existence of the client to the server: resets the server READ timeout.",
     "category": "utility",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "XWB REMOTE CLEAR",
     "desc": "This RPC is used to CLEAR the data under a HANDLE in the ^XTMP global.",
     "category": "utility",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "XWB REMOTE GETDATA",
     "desc": "This RPC will return an ARRAY with what ever data has been sent back fromthe remote site.",
     "category": "utility",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "XWB REMOTE RPC",
     "desc": "This is the RPC that is called to request that an application RPCbe run on a remote system.  The data is passed by HL7 to the remote systemas is the return value.   This RPC will return a HANDLE that can be used to check if the data hasbeen sent back from the remote system.  The HANDLE can be used in anotherRPC to check the status of the RPC.",
     "category": "utility",
-    "locked": false
+    "emulated": false
   },
   {
     "name": "XWB REMOTE STATUS CHECK",
     "desc": "This RPC will return the status of a remote RPC.",
     "category": "utility",
-    "locked": false
+    "emulated": false
   }
 ]

--- a/rpcServer/modelsClinical.js
+++ b/rpcServer/modelsClinical.js
@@ -38,7 +38,7 @@ const mvdmModel = [].concat(
     // patient
     require('mvdm/patient/mvdmPatientModel').mvdmModel);
 
-// Clinical RPC Locker models
+// Clinical RPC Emulator models
 const rpcLModel = [].concat(
     require('mvdm/allergies/rpcLAllergiesModel').rpcLModel,
     require('mvdm/problems/rpcLProblemModel').rpcLModel,

--- a/rpcServer/modelsClinical.js
+++ b/rpcServer/modelsClinical.js
@@ -3,7 +3,7 @@
 'use strict';
 
 /**
- * Clinical models supported by the RPC Server: VDM, MVDM, rpcL
+ * Clinical models supported by the RPC Server: VDM, MVDM, rpcEmulator
  */
 
 // VDM Models
@@ -39,14 +39,14 @@ const mvdmModel = [].concat(
     require('mvdm/patient/mvdmPatientModel').mvdmModel);
 
 // Clinical RPC Emulator models
-const rpcLModel = [].concat(
-    require('mvdm/allergies/rpcLAllergiesModel').rpcLModel,
-    require('mvdm/problems/rpcLProblemModel').rpcLModel,
-    require('mvdm/vitals/rpcLVitalsModel').rpcLModel,
-    require('mvdm/patient/rpcLPatientModel').rpcLModel);
+const rpcEmulatorModel = [].concat(
+    require('mvdm/allergies/rpcEmulatorAllergiesModel').rpcEmulatorModel,
+    require('mvdm/problems/rpcEmulatorProblemModel').rpcEmulatorModel,
+    require('mvdm/vitals/rpcEmulatorVitalsModel').rpcEmulatorModel,
+    require('mvdm/patient/rpcEmulatorPatientModel').rpcEmulatorModel);
 
 module.exports = {
     vdmModel,
     mvdmModel,
-    rpcLModel,
+    rpcEmulatorModel,
 };

--- a/rpcServer/mvdmManagement.js
+++ b/rpcServer/mvdmManagement.js
@@ -3,7 +3,7 @@
 
 //mvdm default management settings
 var mvdmManagement = {
-    isRPCLocked: true
+    isRPCEmulated: true
 };
 
 module.exports = mvdmManagement;

--- a/rpcServer/nodeVISTAManager.js
+++ b/rpcServer/nodeVISTAManager.js
@@ -52,9 +52,9 @@ function init() {
 
         var settings = req.body;
 
-        if (_.has(settings, 'isRPCLocked')) {
-            mvdmManagement.isRPCLocked = settings.isRPCLocked;
-            processAdapter.setRPCLocked(settings.isRPCLocked);
+        if (_.has(settings, 'isRPCEmulated')) {
+            mvdmManagement.isRPCEmulated = settings.isRPCEmulated;
+            processAdapter.setRPCEmulated(settings.isRPCEmulated);
         }
 
         return res.sendStatus(200);

--- a/rpcServer/nodeVISTAManager.js
+++ b/rpcServer/nodeVISTAManager.js
@@ -16,7 +16,7 @@ var EventManager = require('./eventManager');
 var rpcsCategorized = require('./cfg/rpcsCategorized');
 var ProcessAdapter = require('./processAdapter');
 
-var lockedRPCList = [];
+var emulatedRPCList = [];
 
 // Initialize the process adapter, which ties this back into the RPC Server
 const processAdapter = new ProcessAdapter();
@@ -60,9 +60,9 @@ function init() {
         return res.sendStatus(200);
     });
 
-    app.get('/lockedRPCList', function(req, res) {
+    app.get('/emulatedRPCList', function(req, res) {
         res.setHeader('Content-Type', 'application/json');
-        res.end(JSON.stringify(lockedRPCList));
+        res.end(JSON.stringify(emulatedRPCList));
     });
 
     app.get('/rpcList', function(req, res) {
@@ -97,10 +97,10 @@ function init() {
     initMVDMEventListeners(mvdmClients);
     initRPCEventListeners(rpcClients);
 
-    //listen for locked RPC List
-    EventManager.on('lockedRPCList', function(event) {
-        lockedRPCList = event.list.map(function(rpcName) {return {name: rpcName, count: 0};});
-        lockedRPCList.forEach(function(rpc) {
+    //listen for emulated RPC List
+    EventManager.on('emulatedRPCList', function(event) {
+        emulatedRPCList = event.list.map(function(rpcName) {return {name: rpcName, count: 0};});
+        emulatedRPCList.forEach(function(rpc) {
             var category = rpcsCategorized[rpc.name];
             if (category) {
                 rpc = _.extend(rpc, category);

--- a/rpcServer/processAdapter.js
+++ b/rpcServer/processAdapter.js
@@ -101,12 +101,12 @@ class ProcessAdapter {
      * nodeVISTA manager API function. This will allow the nodeVISTAManager to set the MVDM management option on
      * the RPC server side (which used to be a singleton) transparently through the interprocess barrier.
      *
-     * @param {boolean} isRPCLocked State to set the 'isRPCLocked' in the RPC Server
+     * @param {boolean} isRPCEmulated State to set the 'isRPCEmulated' in the RPC Server
      */
-    setRPCLocked(isRPCLocked) {
+    setRPCEmulated(isRPCEmulated) {
         this.sendEventToRPCServer({
-            event: 'isRPCLocked',
-            value: isRPCLocked,
+            event: 'isRPCEmulated',
+            value: isRPCEmulated,
         });
     }
 

--- a/rpcServer/processAdapter.js
+++ b/rpcServer/processAdapter.js
@@ -6,7 +6,7 @@ const _ = require('lodash');
 
 const PROCESS_ADAPTER_CHILD_MODULE = process.env.PROCESS_ADAPTER_CHILD_MODULE || 'nodeVISTAManagerChild.js';
 
-const RPC_SERVER_EVENTS = ['lockedRPCList', 'rpcCall', 'mvdmCreate', 'mvdmDescribe', 'mvdmList', 'mvdmUpdate', 'mvdmRemove', 'mvdmUnremoved', 'mvdmDelete'];
+const RPC_SERVER_EVENTS = ['emulatedRPCList', 'rpcCall', 'mvdmCreate', 'mvdmDescribe', 'mvdmList', 'mvdmUpdate', 'mvdmRemove', 'mvdmUnremoved', 'mvdmDelete'];
 
 /**
  * This class serves two purposes. First, it is responsible for forking and managing the management client application

--- a/rpcServer/rpcDispatcher.js
+++ b/rpcServer/rpcDispatcher.js
@@ -8,11 +8,11 @@ const uuid = require('uuid');
 /**
  * Remote Procedure Call Dispatcher.
  *
- * Dispatches RPC call to an array of RPC lockers.
+ * Dispatches RPC call to an array of RPC emulators.
  *
- * If lockers cannot accommodate handling a RPC call, the dispatcher will default to the RPC runner.
+ * If emulators cannot accommodate handling a RPC call, the dispatcher will default to the RPC runner.
  *
- * By default, lockers will always be invoked. The dispatcher class does provide the ability to turn locking off
+ * By default, emulators will always be invoked. The dispatcher class does provide the ability to turn emulating off
  * for testing purposes.
  *
  */
@@ -20,7 +20,7 @@ class RPCDispatcher {
     /**
      * Constructs instance.
      * @param {Object} db VistA database instance.
-     * @param {Array=} rpcEmulators List of RPC locker implementations to register with the dispatcher (e.g. cRPCL, vprL, ncRPCL)
+     * @param {Array=} rpcEmulators List of RPC emulator implementations to register with the dispatcher (e.g. cRPCL, vprL, ncRPCL)
      */
     constructor(db, rpcEmulators) {
         this.rpcRunner = new RPCRunner(db);
@@ -34,7 +34,7 @@ class RPCDispatcher {
             this.rpcEmulatorList = rpcEmulators;
         }
 
-        this.isEmulated = true; // by default dispatcher run method checks lockers
+        this.isEmulated = true; // by default dispatcher run method checks emulators
 
         // private methods
 
@@ -47,10 +47,10 @@ class RPCDispatcher {
         };
 
         /**
-         * Finds RPC locker implementation that supports a RPC and the given parameters (if provided).
+         * Finds RPC emulator implementation that supports a RPC and the given parameters (if provided).
          * @param {String} rpcName Name of the Remote procedure call.
          * @param {Object=} rpcArgs Remote procedure call arguments.
-         * @returns {Object} Supported locker implementation or null if not found.
+         * @returns {Object} Supported emulator implementation or null if not found.
          */
         this.findSupportedEmulator = function findSupportedEmulator(rpcName, rpcArgs) {
             let supportedEmulator = null;
@@ -69,16 +69,16 @@ class RPCDispatcher {
     }
 
     /**
-     * Sets locking value.
-     * @param {boolean} isON Is locking turned on?
+     * Sets emulating value.
+     * @param {boolean} isON Is emulating turned on?
      */
     setEmulating(isON) {
         this.isEmulated = isON;
     }
 
     /**
-     * Returns a list of all locked RPCs
-     * @returns {Array} list of all locked RPCs
+     * Returns a list of all emulated RPCs
+     * @returns {Array} list of all emulated RPCs
      */
     getEmulatedRPCList() {
         let rpcList = [];
@@ -115,7 +115,7 @@ class RPCDispatcher {
     }
 
     /**
-     * Returns the list of registered RPC lockers.
+     * Returns the list of registered RPC emulators.
      * @returns {RPCL} rpc facade's rpcL instance.
      */
     getRPCEmulators() {
@@ -123,8 +123,8 @@ class RPCDispatcher {
     }
 
     /**
-     * Registers a RPC locker with the dispatcher.
-     * @param {Object} rpcL A RPC locker instance (e.g. cRPCL, vprL).
+     * Registers a RPC emulator with the dispatcher.
+     * @param {Object} rpcL A RPC emulator instance (e.g. cRPCL, vprL).
      */
     registerEmulator(rpcL) {
         this.rpcEmulatorList.push(rpcL);
@@ -133,11 +133,11 @@ class RPCDispatcher {
     /**
      * Dispatch a RPC with arguments.
      *
-     * If locking is turned on, this method will dispatch RPC and arguments to the appropriate RPC locker
-     * that is registered with the class. If no RPC locker is found to accommodates the RPC, by default the RPC will
+     * If emulating is turned on, this method will dispatch RPC and arguments to the appropriate RPC emulator
+     * that is registered with the class. If no RPC emulator is found to accommodates the RPC, by default the RPC will
      * be dispatched to the RPC runner.
      *
-     * If locking is turned off, all calls are dispatched the RPC runner.
+     * If emulating is turned off, all calls are dispatched the RPC runner.
      *
      * @param {String} rpcName VistA remote procedure call name
      * @param {String=} rpcArgs Remote procedure arguments
@@ -147,7 +147,7 @@ class RPCDispatcher {
         let rpcResult;
         let patient;
         let rpcPath;
-        let lockerName;
+        let emulatorName;
 
         // generate a random transaction id for rpcL and rpcRunner calls
         const transactionId = this.generateTransactionId();
@@ -165,7 +165,7 @@ class RPCDispatcher {
             }
 
             rpcPath = 'rpcEmulated';
-            lockerName = rpcL.name || 'Unknown';
+            emulatorName = rpcL.name || 'Unknown';
 
             rpcResult = rpcL.run(rpcName, rpcArgs, transactionId);
 
@@ -193,7 +193,7 @@ class RPCDispatcher {
 
         const ret = {
             path: rpcPath,
-            lockerName,
+            emulatorName,
             rpcResponse: response,
             transactionId,
             result: rpcResult.result,

--- a/rpcServer/rpcDispatcher.js
+++ b/rpcServer/rpcDispatcher.js
@@ -20,7 +20,7 @@ class RPCDispatcher {
     /**
      * Constructs instance.
      * @param {Object} db VistA database instance.
-     * @param {Array=} rpcEmulators List of RPC emulator implementations to register with the dispatcher (e.g. cRPCL, vprL, ncRPCL)
+     * @param {Array=} rpcEmulators List of RPC emulator implementations to register with the dispatcher (e.g. cRPCEmulator, vprL, ncRPCEmulator)
      */
     constructor(db, rpcEmulators) {
         this.rpcRunner = new RPCRunner(db);
@@ -56,10 +56,10 @@ class RPCDispatcher {
             let supportedEmulator = null;
 
             for (let i = 0; i < this.rpcEmulatorList.length; i += 1) {
-                const rpcL = this.rpcEmulatorList[i];
+                const rpcEmulator = this.rpcEmulatorList[i];
 
-                if (rpcL.isRPCSupported(rpcName, rpcArgs)) {
-                    supportedEmulator = rpcL;
+                if (rpcEmulator.isRPCSupported(rpcName, rpcArgs)) {
+                    supportedEmulator = rpcEmulator;
                     break;
                 }
             }
@@ -83,8 +83,8 @@ class RPCDispatcher {
     getEmulatedRPCList() {
         let rpcList = [];
 
-        this.rpcEmulatorList.forEach((rpcL) => {
-            rpcList = rpcList.concat(rpcL.getEmulatedRPCList());
+        this.rpcEmulatorList.forEach((rpcEmulator) => {
+            rpcList = rpcList.concat(rpcEmulator.getEmulatedRPCList());
         });
 
         return rpcList;
@@ -116,7 +116,7 @@ class RPCDispatcher {
 
     /**
      * Returns the list of registered RPC emulators.
-     * @returns {RPCL} rpc facade's rpcL instance.
+     * @returns {RPCEmulator} rpc facade's rpcEmulator instance.
      */
     getRPCEmulators() {
         return this.rpcEmulatorList;
@@ -124,10 +124,10 @@ class RPCDispatcher {
 
     /**
      * Registers a RPC emulator with the dispatcher.
-     * @param {Object} rpcL A RPC emulator instance (e.g. cRPCL, vprL).
+     * @param {Object} rpcEmulator A RPC emulator instance (e.g. cRPCEmulator, vprL).
      */
-    registerEmulator(rpcL) {
-        this.rpcEmulatorList.push(rpcL);
+    registerEmulator(rpcEmulator) {
+        this.rpcEmulatorList.push(rpcEmulator);
     }
 
     /**
@@ -149,15 +149,15 @@ class RPCDispatcher {
         let rpcPath;
         let emulatorName;
 
-        // generate a random transaction id for rpcL and rpcRunner calls
+        // generate a random transaction id for rpcEmulator and rpcRunner calls
         const transactionId = this.generateTransactionId();
 
-        const rpcL = this.findSupportedEmulator(rpcName, rpcArgs);
+        const rpcEmulator = this.findSupportedEmulator(rpcName, rpcArgs);
 
-        if (this.isEmulated && rpcL !== null) {
+        if (this.isEmulated && rpcEmulator !== null) {
             // Since last pass (or this is first pass), user may have changed. Ask rpcRunner.
             const uNf = this.rpcRunner.getUserAndFacility();
-            rpcL.setUserAndFacility(uNf.userId, uNf.facilityId);
+            rpcEmulator.setUserAndFacility(uNf.userId, uNf.facilityId);
 
             // Proxy for "logged in". userId is 0 if not logged in
             if (uNf.userId === 0) {
@@ -165,9 +165,9 @@ class RPCDispatcher {
             }
 
             rpcPath = 'rpcEmulated';
-            emulatorName = rpcL.name || 'Unknown';
+            emulatorName = rpcEmulator.name || 'Unknown';
 
-            rpcResult = rpcL.run(rpcName, rpcArgs, transactionId);
+            rpcResult = rpcEmulator.run(rpcName, rpcArgs, transactionId);
 
             if (rpcResult.patient) {
                 patient = rpcResult.patient;

--- a/rpcServer/rpcQWorker.js
+++ b/rpcServer/rpcQWorker.js
@@ -130,8 +130,8 @@ function createDispatcher() {
 
                     rpcEmulator.addMVDMModel(mvdmModels);
                 }
-                if (model.rpcLModel) {
-                    rpcEmulator.addEmulatorModel(model.rpcLModel);
+                if (model.rpcEmulatorModel) {
+                    rpcEmulator.addEmulatorModel(model.rpcEmulatorModel);
                 }
             });
 
@@ -371,7 +371,7 @@ module.exports = function() {
         } else if (messageObj.method === 'emulatedRPCList') {
 
             finished({
-                type: 'rpcL',
+                type: 'rpcEmulator',
                 event: {
                     list: rpcDispatcher.getEmulatedRPCList()
                 },

--- a/rpcServer/rpcQWorker.js
+++ b/rpcServer/rpcQWorker.js
@@ -68,20 +68,20 @@ function setGtmRoutinePath() {
  *
  * This function also registers RPC lockers based on server configuration properties.
  *
- * Locker and Model instances are dynamically instantiated based on configuration options, which decouples the
+ * Emulator and Model instances are dynamically instantiated based on configuration options, which decouples the
  * target locker/model code from the worker. It also precludes the need for special "developer mode" flags and
  * gives sever user more control over the registration process.
  *
  * To configure registration of lockers, the function depends the 'CONFIG.lockers' attribute, which
- * should be an array of Locker configuration objects. The objects should have the following format:
+ * should be an array of Emulator configuration objects. The objects should have the following format:
  *
  *    locker.name: {String} <OPTIONAL> Arbitrary string name of the locker.
- *    locker.path: {String} <REQUIRED> Relative or absolute path of the Locker class definition module,
+ *    locker.path: {String} <REQUIRED> Relative or absolute path of the Emulator class definition module,
  *                 in CommonJS format.
  *    locker.models: {Array} <REQUIRED> Relative or absolute paths to the model definition modules, in CommonJS format.
  *    locker.routinePath: {String} <OPTIONAL> Path to additional required MUMPS routines.
  *
- * Order matters with respect to the configuration objects. Lockers listed earlier in the CONFIG.lockers array will
+ * Order matters with respect to the configuration objects. Emulators listed earlier in the CONFIG.lockers array will
  * be given higher precedence in the dispatcher handler.
  */
 function createDispatcher() {
@@ -101,13 +101,13 @@ function createDispatcher() {
 
         // We're going to be doing dynamic 'requires', so we'll need to catch any errors if they occur
         try {
-            LOGGER.debug(`Creating instance of RPC Locker class from ${locker.path}`);
+            LOGGER.debug(`Creating instance of RPC Emulator class from ${locker.path}`);
 
             // eslint-disable-next-line
-            const LockerClass = require(locker.path);
-            const rpcLocker = new LockerClass(db);
+            const EmulatorClass = require(locker.path);
+            const rpcEmulator = new EmulatorClass(db);
 
-            rpcLocker.name = name;
+            rpcEmulator.name = name;
 
             // If that was successful, load all the models specified for this locker via module paths
             const modelPaths = locker.models || [];
@@ -122,21 +122,21 @@ function createDispatcher() {
                     // add to existing vdm model list (VDM is a singleton)
                     vdmModels = vdmModels.concat(model.vdmModel);
 
-                    rpcLocker.addVDMModel(vdmModels);
+                    rpcEmulator.addVDMModel(vdmModels);
                 }
                 if (model.mvdmModel) {
                     // add to existing MVDM list (MVDM is a singleton)
                     mvdmModels = mvdmModels.concat(model.mvdmModel);
 
-                    rpcLocker.addMVDMModel(mvdmModels);
+                    rpcEmulator.addMVDMModel(mvdmModels);
                 }
                 if (model.rpcLModel) {
-                    rpcLocker.addLockerModel(model.rpcLModel);
+                    rpcEmulator.addEmulatorModel(model.rpcLModel);
                 }
             });
 
             // If everything was successful and we didn't raise an exception, we register the locker with the dispatcher
-            rpcDispatcher.registerLocker(rpcLocker);
+            rpcDispatcher.registerEmulator(rpcEmulator);
 
             LOGGER.info(`Successfully registered locker: ${name}`);
         } catch (e) {
@@ -165,7 +165,7 @@ function generateTransactionId() {
 /**
  * This takes the object (rpcObject) from the parsed RPC string (rpcPacket) and passes it
  * to the rpcService. For connection type commands such as TCPConnect and #BYE#,
- * the server will send a fixed response instead of calling the RPC Locker or RPC Runner.
+ * the server will send a fixed response instead of calling the RPC Emulator or RPC Runner.
  *
  * @param rpcObject js object returned from rpc parser
  * @param rpcPacket the raw rpc string
@@ -344,7 +344,7 @@ module.exports = function() {
 
         // now check the message to setup callbacks to the rpcServer after running the rpc or other messages
         if (messageObj.method === 'callRPC') {
-            rpcDispatcher.setLocking(messageObj.isRPCLocked);
+            rpcDispatcher.setEmulating(messageObj.isRPCEmulated);
 
             LOGGER.debug('rpcQWorker in on(\'message\'), callRPC messageObj: %j ', messageObj);
 
@@ -373,7 +373,7 @@ module.exports = function() {
             finished({
                 type: 'rpcL',
                 event: {
-                    list: rpcDispatcher.getLockedRPCList()
+                    list: rpcDispatcher.getEmulatedRPCList()
                 },
                 eventType: 'lockedRPCList'
             });

--- a/rpcServer/rpcQWorker.js
+++ b/rpcServer/rpcQWorker.js
@@ -51,13 +51,13 @@ function connectVistaDatabase() {
 function setGtmRoutinePath() {
     const pathElements = [process.env.gtmroutines, vdmUtils.getVdmPath()];
 
-    const lockers = CONFIG.lockers || [];
-    lockers.forEach((locker) => {
+    const emulators = CONFIG.emulators || [];
+    emulators.forEach((emulator) => {
 
-        // Add the MUMPS routine paths any exist for this locker configuration
-        if (locker.routinePath) {
-            LOGGER.debug(`Appending ${locker.routinePath} to the gtmroutines environment variable`);
-            pathElements.push(locker.routinePath);
+        // Add the MUMPS routine paths any exist for this emulator configuration
+        if (emulator.routinePath) {
+            LOGGER.debug(`Appending ${emulator.routinePath} to the gtmroutines environment variable`);
+            pathElements.push(emulator.routinePath);
         }
     });
     return pathElements.join(' ');
@@ -66,22 +66,22 @@ function setGtmRoutinePath() {
 /**
  * Create and initialize RPC dispatcher.
  *
- * This function also registers RPC lockers based on server configuration properties.
+ * This function also registers RPC emulators based on server configuration properties.
  *
  * Emulator and Model instances are dynamically instantiated based on configuration options, which decouples the
- * target locker/model code from the worker. It also precludes the need for special "developer mode" flags and
+ * target emulator/model code from the worker. It also precludes the need for special "developer mode" flags and
  * gives sever user more control over the registration process.
  *
- * To configure registration of lockers, the function depends the 'CONFIG.lockers' attribute, which
+ * To configure registration of emulators, the function depends the 'CONFIG.emulators' attribute, which
  * should be an array of Emulator configuration objects. The objects should have the following format:
  *
- *    locker.name: {String} <OPTIONAL> Arbitrary string name of the locker.
- *    locker.path: {String} <REQUIRED> Relative or absolute path of the Emulator class definition module,
+ *    emulator.name: {String} <OPTIONAL> Arbitrary string name of the emulator.
+ *    emulator.path: {String} <REQUIRED> Relative or absolute path of the Emulator class definition module,
  *                 in CommonJS format.
- *    locker.models: {Array} <REQUIRED> Relative or absolute paths to the model definition modules, in CommonJS format.
- *    locker.routinePath: {String} <OPTIONAL> Path to additional required MUMPS routines.
+ *    emulator.models: {Array} <REQUIRED> Relative or absolute paths to the model definition modules, in CommonJS format.
+ *    emulator.routinePath: {String} <OPTIONAL> Path to additional required MUMPS routines.
  *
- * Order matters with respect to the configuration objects. Emulators listed earlier in the CONFIG.lockers array will
+ * Order matters with respect to the configuration objects. Emulators listed earlier in the CONFIG.emulators array will
  * be given higher precedence in the dispatcher handler.
  */
 function createDispatcher() {
@@ -89,35 +89,35 @@ function createDispatcher() {
     // create RPC dispatcher
     rpcDispatcher = new RPCDispatcher(db);
 
-    // Grab the locker definition object array from the configuration
-    const lockers = CONFIG.lockers || [];
+    // Grab the emulator definition object array from the configuration
+    const emulators = CONFIG.emulators || [];
 
     let vdmModels = [];
     let mvdmModels = [];
 
-    lockers.forEach((locker) => {
-        const name = locker.name || 'UNKNOWN';
-        LOGGER.info(`Registering locker: ${name}...`);
+    emulators.forEach((emulator) => {
+        const name = emulator.name || 'UNKNOWN';
+        LOGGER.info(`Registering emulator: ${name}...`);
 
         // We're going to be doing dynamic 'requires', so we'll need to catch any errors if they occur
         try {
-            LOGGER.debug(`Creating instance of RPC Emulator class from ${locker.path}`);
+            LOGGER.debug(`Creating instance of RPC Emulator class from ${emulator.path}`);
 
             // eslint-disable-next-line
-            const EmulatorClass = require(locker.path);
+            const EmulatorClass = require(emulator.path);
             const rpcEmulator = new EmulatorClass(db);
 
             rpcEmulator.name = name;
 
-            // If that was successful, load all the models specified for this locker via module paths
-            const modelPaths = locker.models || [];
+            // If that was successful, load all the models specified for this emulator via module paths
+            const modelPaths = emulator.models || [];
             modelPaths.forEach((modelPath) => {
                 LOGGER.debug(`Loading models from ${modelPath}`);
 
                 // eslint-disable-next-line
                 const model = require(modelPath);
 
-                // Inject model dependencies into the locker instance
+                // Inject model dependencies into the emulator instance
                 if (model.vdmModel) {
                     // add to existing vdm model list (VDM is a singleton)
                     vdmModels = vdmModels.concat(model.vdmModel);
@@ -135,12 +135,12 @@ function createDispatcher() {
                 }
             });
 
-            // If everything was successful and we didn't raise an exception, we register the locker with the dispatcher
+            // If everything was successful and we didn't raise an exception, we register the emulator with the dispatcher
             rpcDispatcher.registerEmulator(rpcEmulator);
 
-            LOGGER.info(`Successfully registered locker: ${name}`);
+            LOGGER.info(`Successfully registered emulator: ${name}`);
         } catch (e) {
-            LOGGER.error(`ERROR registering locker: ${name} - ${e.toString()}`);
+            LOGGER.error(`ERROR registering emulator: ${name} - ${e.toString()}`);
         }
     });
 }
@@ -189,7 +189,7 @@ function callRPC(messageObject, send) {
         response = unsupportedRPCs.get(rpcObject.name);
         rpcObject.to = "server";
     } else {
-        // These are normal RPCs that can go to either the locker or the runner.
+        // These are normal RPCs that can go to either the emulator or the runner.
         LOGGER.debug("calling RPC service");
 
         // Wrap the dispatcher in a try/catch block to allow for error condition logging
@@ -205,7 +205,7 @@ function callRPC(messageObject, send) {
                 rpcResponse: e.message,
                 transactionId: e.errno,
                 result: e.message,
-                lockerName: 'ERROR',
+                emulatorName: 'ERROR',
             };
         }
 
@@ -213,7 +213,7 @@ function callRPC(messageObject, send) {
         response = ret.rpcResponse;
         transactionId = ret.transactionId;
         runResult = ret.result;
-        rpcObject.lockerName = ret.lockerName;
+        rpcObject.emulatorName = ret.emulatorName;
     }
 
     // log to capture file the RPC and the response to a file
@@ -231,7 +231,7 @@ function callRPC(messageObject, send) {
             ipAddress: messageObject.ipAddress,
             timestamp: rpcObject.timeStamp,
             runner: rpcObject.to,
-            lockerName: rpcObject.lockerName,
+            emulatorName: rpcObject.emulatorName,
             runResult: runResult,
             rpcName: rpcObject.name,
             rpcObject: rpcObject,
@@ -368,14 +368,14 @@ module.exports = function() {
                 rpcContexts.clearAll();
             }
             finished();
-        } else if (messageObj.method === 'lockedRPCList') {
+        } else if (messageObj.method === 'emulatedRPCList') {
 
             finished({
                 type: 'rpcL',
                 event: {
                     list: rpcDispatcher.getEmulatedRPCList()
                 },
-                eventType: 'lockedRPCList'
+                eventType: 'emulatedRPCList'
             });
         }
     });

--- a/rpcServer/rpcServer.js
+++ b/rpcServer/rpcServer.js
@@ -63,8 +63,8 @@ processQueue.start();
 // = Initialize the process adapter which spawns and links the nodeVISTAManager in a new process ==
 const processAdapter = new ProcessAdapter();
 processAdapter.bindEventManager(EventManager);
-processAdapter.registerChildEventHandler('isRPCLocked', (isRPCLocked) => {
-    mvdmManagement.isRPCLocked = isRPCLocked;
+processAdapter.registerChildEventHandler('isRPCEmulated', (isRPCEmulated) => {
+    mvdmManagement.isRPCEmulated = isRPCEmulated;
 });
 // =================================================================================================
 
@@ -130,7 +130,7 @@ function handleConnection(conn) {
             messageObject.method = 'callRPC';
             messageObject.ipAddress = conn.remoteAddress;
             messageObject.rpcPacket = rpcPacket;
-            messageObject.isRPCLocked = mvdmManagement.isRPCLocked;
+            messageObject.isRPCEmulated = mvdmManagement.isRPCEmulated;
             messageObject.contextId = remoteAddress;
             processQueue.handleMessage(messageObject, function(responseObject) {
                 LOGGER.debug("in rpcServer handleMessage from rpc responseObject = %j", responseObject);

--- a/rpcServer/rpcServer.js
+++ b/rpcServer/rpcServer.js
@@ -80,8 +80,8 @@ captureFile.on("open", function (fd) {
     server.listen(port, function () {
         LOGGER.info('RPCServer listening to %j', server.address());
 
-        //get locked rpc list
-        processQueue.handleMessage({method: 'lockedRPCList'}, function(responseObject) {
+        //get emulated rpc list
+        processQueue.handleMessage({method: 'emulatedRPCList'}, function(responseObject) {
             EventManager.emit(responseObject.message.eventType, responseObject.message.event);
         });
     });


### PR DESCRIPTION
Like the pull request (https://github.com/vistadataproject/VDM/pull/238) in VDM, I thought this was going to be a simple one...naively, I thought, "How many times can the terms 'LOCKER' and 'rpcL' show in this repo anyway". Well, it turns out that it's about 27 files worth. I'm pretty sure I caught them all, but I need some help sanity checking the changes.

Note that a similar change was done for nonClinicalRPCs and for VDM, and these changes are all interdependent.